### PR TITLE
fix: use correct file format for LL-HLS fMP4 streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Available options:
 --cookies value             Cookies to use in the request (format: key=value; key2=value2)
 --user-agent value          Custom User-Agent for the request
 --domain value              Chaturbate domain to use (default: "https://chaturbate.global/")
---compress                  Compress .ts to .mkv after recording (auto-enabled if ffmpeg installed)
+--compress                  Compress recorded .ts or .mp4 files to .mkv after recording (auto-enabled if ffmpeg installed)
 --help, -h                  show help
 --version, -v               print the version
 ```
@@ -192,7 +192,7 @@ Default it hides the sequence if it's zero.
 
 ```
 Pattern: {{.Username}}_{{.Year}}-{{.Month}}-{{.Day}}_{{.Hour}}-{{.Minute}}-{{.Second}}{{if .Sequence}}_{{.Sequence}}{{end}}
- Output: yamiodymel_2024-01-02_13-45-00.ts    # Sequence won't be shown if it's zero.
+ Output: yamiodymel_2024-01-02_13-45-00.ts    # Legacy HLS output
  Output: yamiodymel_2024-01-02_13-45-00_1.ts
 ```
 
@@ -211,7 +211,7 @@ Pattern: video/{{.Username}}/{{.Year}}-{{.Month}}-{{.Day}}_{{.Hour}}-{{.Minute}}
  Output: video/yamiodymel/2024-01-02_13-45-00_0.ts
 ```
 
-_Note: Files are saved in `.ts` format, and this is not configurable._
+_Note: output format follows the stream container: legacy HLS is saved as `.ts`, LL-HLS/fMP4 is saved as `.mp4`._
 
 &nbsp;
 

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -29,9 +29,13 @@ type Channel struct {
 
 	Logs []string
 
-	File        *os.File
-	Config      *entity.ChannelConfig
-	InitSegment []byte // fMP4 init segment (moov atom) for LL-HLS streams
+	File             *os.File
+	AudioFile        *os.File
+	Config           *entity.ChannelConfig
+	CurrentFilename  string
+	InitSegment      []byte // fMP4 video init segment for LL-HLS streams
+	AudioInitSegment []byte // fMP4 audio init segment for LL-HLS streams
+	HasSeparateAudio bool
 }
 
 // New creates a new channel instance with the given manager and configuration.
@@ -91,7 +95,9 @@ func (ch *Channel) Error(format string, a ...any) {
 // ExportInfo exports the channel information as a ChannelInfo struct.
 func (ch *Channel) ExportInfo() *entity.ChannelInfo {
 	var filename string
-	if ch.File != nil {
+	if ch.CurrentFilename != "" && ch.HasSeparateAudio {
+		filename = ch.CurrentFilename + ".mp4"
+	} else if ch.File != nil {
 		filename = ch.File.Name()
 	}
 	var streamedAt string

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -29,8 +29,9 @@ type Channel struct {
 
 	Logs []string
 
-	File   *os.File
-	Config *entity.ChannelConfig
+	File        *os.File
+	Config      *entity.ChannelConfig
+	InitSegment []byte // fMP4 init segment (moov atom) for LL-HLS streams
 }
 
 // New creates a new channel instance with the given manager and configuration.

--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -66,37 +66,38 @@ func getEncoder() videoEncoder {
 	return availableEncoders[len(availableEncoders)-1]
 }
 
-// CompressFile compresses a .ts file to .mkv format using ffmpeg in the background.
+// CompressFile compresses a video file (.ts or .mp4) to .mkv format using ffmpeg in the background.
 // Uses hardware GPU encoding if available, falls back to CPU (libx264).
-// After successful compression, the original .ts file is deleted.
-func (ch *Channel) CompressFile(tsPath string) {
+// After successful compression, the original file is deleted.
+func (ch *Channel) CompressFile(srcPath string) {
 	go func() {
-		mkvPath := strings.TrimSuffix(tsPath, ".ts") + ".mkv"
-		tsFilename := filepath.Base(tsPath)
+		ext := filepath.Ext(srcPath)
+		mkvPath := strings.TrimSuffix(srcPath, ext) + ".mkv"
+		srcFilename := filepath.Base(srcPath)
 		mkvFilename := filepath.Base(mkvPath)
 
 		// Get original file size
-		tsInfo, err := os.Stat(tsPath)
+		srcInfo, err := os.Stat(srcPath)
 		if err != nil {
 			ch.Error("compress: failed to stat file: %s", err.Error())
 			return
 		}
-		tsSize := tsInfo.Size()
+		srcSize := srcInfo.Size()
 
 		// Get the best available encoder
 		encoder := getEncoder()
 
-		ch.Info("compress: encoding %s (%s) using %s", tsFilename, internal.FormatFilesize(int(tsSize)), encoder.name)
+		ch.Info("compress: encoding %s (%s) using %s", srcFilename, internal.FormatFilesize(int(srcSize)), encoder.name)
 
 		// Build ffmpeg command
-		args := []string{"-y", "-i", tsPath, "-c:v", encoder.codec}
+		args := []string{"-y", "-i", srcPath, "-c:v", encoder.codec}
 		args = append(args, encoder.args...)
 		args = append(args, "-c:a", "aac", "-b:a", "128k", mkvPath)
 
 		cmd := exec.Command("ffmpeg", args...)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			ch.Error("compress: failed %s - %s", tsFilename, err.Error())
+			ch.Error("compress: failed %s - %s", srcFilename, err.Error())
 			if len(output) > 0 {
 				// Only show last 500 chars of ffmpeg output to avoid flooding logs
 				outStr := string(output)
@@ -117,14 +118,14 @@ func (ch *Channel) CompressFile(tsPath string) {
 		mkvSize := mkvInfo.Size()
 
 		// Calculate compression ratio
-		ratio := float64(mkvSize) / float64(tsSize) * 100
+		ratio := float64(mkvSize) / float64(srcSize) * 100
 
-		// Delete the original .ts file after successful compression
-		if err := os.Remove(tsPath); err != nil {
-			ch.Error("compress: failed to delete %s - %s", tsFilename, err.Error())
+		// Delete the original file after successful compression
+		if err := os.Remove(srcPath); err != nil {
+			ch.Error("compress: failed to delete %s - %s", srcFilename, err.Error())
 			return
 		}
 
-		ch.Info("compress: done %s -> %s (%s, %.1f%%)", tsFilename, mkvFilename, internal.FormatFilesize(int(mkvSize)), ratio)
+		ch.Info("compress: done %s -> %s (%s, %.1f%%)", srcFilename, mkvFilename, internal.FormatFilesize(int(mkvSize)), ratio)
 	}()
 }

--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,9 +19,9 @@ var (
 
 // videoEncoder represents a video encoder configuration
 type videoEncoder struct {
-	name   string   // display name
-	codec  string   // ffmpeg codec name
-	args   []string // additional encoder arguments
+	name  string   // display name
+	codec string   // ffmpeg codec name
+	args  []string // additional encoder arguments
 }
 
 // availableEncoders lists GPU encoders in priority order, with CPU fallback last
@@ -128,4 +129,33 @@ func (ch *Channel) CompressFile(srcPath string) {
 
 		ch.Info("compress: done %s -> %s (%s, %.1f%%)", srcFilename, mkvFilename, internal.FormatFilesize(int(mkvSize)), ratio)
 	}()
+}
+
+// MuxAV combines separate video and audio source files into a single MP4 container.
+func (ch *Channel) MuxAV(videoPath, audioPath, outputPath string) error {
+	args := []string{
+		"-y",
+		"-i", videoPath,
+		"-i", audioPath,
+		"-map", "0:v:0",
+		"-map", "1:a:0",
+		"-c", "copy",
+		outputPath,
+	}
+
+	cmd := exec.Command("ffmpeg", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if len(output) > 0 {
+			outStr := string(output)
+			if len(outStr) > 500 {
+				outStr = outStr[len(outStr)-500:]
+			}
+			ch.Error("mux: ffmpeg: %s", outStr)
+		}
+		return fmt.Errorf("mux audio/video: %w", err)
+	}
+
+	ch.Info("mux: combined %s + %s -> %s", filepath.Base(videoPath), filepath.Base(audioPath), filepath.Base(outputPath))
+	return nil
 }

--- a/channel/channel_file.go
+++ b/channel/channel_file.go
@@ -31,6 +31,7 @@ func (ch *Channel) NextFile() error {
 	if err != nil {
 		return err
 	}
+	ch.CurrentFilename = filename
 	if err := ch.CreateNewFile(filename); err != nil {
 		return err
 	}
@@ -42,39 +43,57 @@ func (ch *Channel) NextFile() error {
 
 // Cleanup cleans the file and resets it, called when the stream errors out or before next file was created.
 func (ch *Channel) Cleanup() error {
-	if ch.File == nil {
+	if ch.File == nil && ch.AudioFile == nil {
 		return nil
 	}
-	filename := ch.File.Name()
+	currentFilename := ch.CurrentFilename
 
 	defer func() {
-		ch.File = nil // Prevent duplicate cleanup
+		ch.File = nil
+		ch.AudioFile = nil
+		ch.CurrentFilename = ""
 		ch.Filesize = 0
 		ch.Duration = 0
 	}()
 
-	// Sync the file to ensure data is written to disk
-	if err := ch.File.Sync(); err != nil && !errors.Is(err, os.ErrClosed) {
-		return fmt.Errorf("sync file: %w", err)
+	videoFilename, videoInfo, err := closeTrackedFile(ch.File)
+	if err != nil {
+		return err
 	}
-	if err := ch.File.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
-		return fmt.Errorf("close file: %w", err)
+	audioFilename, audioInfo, err := closeTrackedFile(ch.AudioFile)
+	if err != nil {
+		return err
 	}
 
-	// Delete the empty file
-	fileInfo, err := os.Stat(filename)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("stat file delete zero file: %w", err)
-	}
-	if fileInfo != nil && fileInfo.Size() == 0 {
-		if err := os.Remove(filename); err != nil {
-			return fmt.Errorf("remove zero file: %w", err)
+	if ch.HasSeparateAudio {
+		switch {
+		case videoInfo == nil && audioInfo == nil:
+			return nil
+		case videoInfo == nil || audioInfo == nil:
+			if videoFilename != "" {
+				_ = os.Remove(videoFilename)
+			}
+			if audioFilename != "" {
+				_ = os.Remove(audioFilename)
+			}
+			return fmt.Errorf("separate audio stream incomplete, dropping partial output")
 		}
+
+		finalOutput := currentFilename + ".mp4"
+		if err := ch.MuxAV(videoFilename, audioFilename, finalOutput); err != nil {
+			return err
+		}
+		_ = os.Remove(videoFilename)
+		_ = os.Remove(audioFilename)
+
+		if ch.Config.Compress {
+			ch.CompressFile(finalOutput)
+		}
+		return nil
 	}
 
-	// Compress the file if enabled and has content
-	if ch.Config.Compress && fileInfo != nil && fileInfo.Size() > 0 {
-		ch.CompressFile(filename)
+	if ch.Config.Compress && videoInfo != nil && videoInfo.Size() > 0 {
+		ch.CompressFile(videoFilename)
 	}
 
 	return nil
@@ -111,27 +130,18 @@ func (ch *Channel) GenerateFilename() (string, error) {
 
 // CreateNewFile creates a new file for the channel using the given filename
 func (ch *Channel) CreateNewFile(filename string) error {
-
 	// Ensure the directory exists before creating the file
 	if err := os.MkdirAll(filepath.Dir(filename), 0777); err != nil {
 		return fmt.Errorf("mkdir all: %w", err)
 	}
 
-	// Use .mp4 for fMP4/LL-HLS streams, .ts for legacy HLS
-	ext := ".ts"
-	if len(ch.InitSegment) > 0 {
-		ext = ".mp4"
-	}
-
-	// Open the file in append mode, create it if it doesn't exist
-	file, err := os.OpenFile(filename+ext, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0777)
+	videoPath := ch.videoPath(filename)
+	file, err := os.OpenFile(videoPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0777)
 	if err != nil {
 		return fmt.Errorf("cannot open file: %s: %w", filename, err)
 	}
-
 	ch.File = file
 
-	// Write the init segment (moov atom) at the start of each fMP4 file
 	if len(ch.InitSegment) > 0 {
 		n, err := ch.File.Write(ch.InitSegment)
 		if err != nil {
@@ -140,7 +150,79 @@ func (ch *Channel) CreateNewFile(filename string) error {
 		ch.Filesize += n
 	}
 
+	if ch.HasSeparateAudio {
+		audioPath := ch.audioPath(filename)
+		audioFile, err := os.OpenFile(audioPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0777)
+		if err != nil {
+			_ = ch.File.Close()
+			ch.File = nil
+			return fmt.Errorf("cannot open audio file: %s: %w", filename, err)
+		}
+		ch.AudioFile = audioFile
+
+		if len(ch.AudioInitSegment) > 0 {
+			if _, err := ch.AudioFile.Write(ch.AudioInitSegment); err != nil {
+				_ = ch.File.Close()
+				_ = ch.AudioFile.Close()
+				ch.File = nil
+				ch.AudioFile = nil
+				return fmt.Errorf("write audio init segment: %w", err)
+			}
+		}
+	}
+
 	return nil
+}
+
+func (ch *Channel) videoPath(filename string) string {
+	if ch.HasSeparateAudio {
+		ext := ".video.ts"
+		if len(ch.InitSegment) > 0 {
+			ext = ".video.mp4"
+		}
+		return filename + ext
+	}
+
+	ext := ".ts"
+	if len(ch.InitSegment) > 0 {
+		ext = ".mp4"
+	}
+	return filename + ext
+}
+
+func (ch *Channel) audioPath(filename string) string {
+	ext := ".audio.ts"
+	if len(ch.AudioInitSegment) > 0 {
+		ext = ".audio.mp4"
+	}
+	return filename + ext
+}
+
+func closeTrackedFile(file *os.File) (string, os.FileInfo, error) {
+	if file == nil {
+		return "", nil, nil
+	}
+
+	filename := file.Name()
+	if err := file.Sync(); err != nil && !errors.Is(err, os.ErrClosed) {
+		return "", nil, fmt.Errorf("sync file: %w", err)
+	}
+	if err := file.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+		return "", nil, fmt.Errorf("close file: %w", err)
+	}
+
+	fileInfo, err := os.Stat(filename)
+	if err != nil && !os.IsNotExist(err) {
+		return "", nil, fmt.Errorf("stat file delete zero file: %w", err)
+	}
+	if fileInfo != nil && fileInfo.Size() == 0 {
+		if err := os.Remove(filename); err != nil {
+			return "", nil, fmt.Errorf("remove zero file: %w", err)
+		}
+		fileInfo = nil
+	}
+
+	return filename, fileInfo, nil
 }
 
 // ShouldSwitchFile determines whether a new file should be created.

--- a/channel/channel_file.go
+++ b/channel/channel_file.go
@@ -117,13 +117,29 @@ func (ch *Channel) CreateNewFile(filename string) error {
 		return fmt.Errorf("mkdir all: %w", err)
 	}
 
+	// Use .mp4 for fMP4/LL-HLS streams, .ts for legacy HLS
+	ext := ".ts"
+	if len(ch.InitSegment) > 0 {
+		ext = ".mp4"
+	}
+
 	// Open the file in append mode, create it if it doesn't exist
-	file, err := os.OpenFile(filename+".ts", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0777)
+	file, err := os.OpenFile(filename+ext, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0777)
 	if err != nil {
 		return fmt.Errorf("cannot open file: %s: %w", filename, err)
 	}
 
 	ch.File = file
+
+	// Write the init segment (moov atom) at the start of each fMP4 file
+	if len(ch.InitSegment) > 0 {
+		n, err := ch.File.Write(ch.InitSegment)
+		if err != nil {
+			return fmt.Errorf("write init segment: %w", err)
+		}
+		ch.Filesize += n
+	}
+
 	return nil
 }
 

--- a/channel/channel_record.go
+++ b/channel/channel_record.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -86,6 +89,7 @@ func (ch *Channel) RecordStream(ctx context.Context, client *chaturbate.Client) 
 	}
 	ch.StreamedAt = time.Now().Unix()
 	ch.Sequence = 0
+	ch.InitSegment = nil
 
 	if err := ch.NextFile(); err != nil {
 		return fmt.Errorf("next file: %w", err)
@@ -107,7 +111,42 @@ func (ch *Channel) RecordStream(ctx context.Context, client *chaturbate.Client) 
 
 	ch.Info("stream quality - resolution %dp (target: %dp), framerate %dfps (target: %dfps)", playlist.Resolution, ch.Config.Resolution, playlist.Framerate, ch.Config.Framerate)
 
-	return playlist.WatchSegments(ctx, ch.HandleSegment)
+	return playlist.WatchSegments(ctx, ch.HandleSegment, ch.HandleInitSegment)
+}
+
+// HandleInitSegment stores the fMP4 init segment and reopens the file with the correct extension.
+func (ch *Channel) HandleInitSegment(initData []byte) {
+	ch.InitSegment = initData
+
+	if ch.File == nil {
+		return
+	}
+
+	oldName := ch.File.Name()
+	if err := ch.File.Close(); err != nil {
+		ch.Error("close file for rename: %s", err.Error())
+		return
+	}
+
+	newName := strings.TrimSuffix(oldName, filepath.Ext(oldName)) + ".mp4"
+	if err := os.Rename(oldName, newName); err != nil {
+		ch.Error("rename file to mp4: %s", err.Error())
+		return
+	}
+
+	file, err := os.OpenFile(newName, os.O_APPEND|os.O_WRONLY, 0777)
+	if err != nil {
+		ch.Error("reopen file as mp4: %s", err.Error())
+		return
+	}
+	ch.File = file
+
+	n, err := ch.File.Write(initData)
+	if err != nil {
+		ch.Error("write init segment: %s", err.Error())
+		return
+	}
+	ch.Filesize += n
 }
 
 // HandleSegment processes and writes segment data to a file.

--- a/channel/channel_record.go
+++ b/channel/channel_record.go
@@ -87,9 +87,16 @@ func (ch *Channel) RecordStream(ctx context.Context, client *chaturbate.Client) 
 	if err != nil {
 		return fmt.Errorf("get stream: %w", err)
 	}
+	playlist, err := stream.GetPlaylist(ctx, ch.Config.Resolution, ch.Config.Framerate)
+	if err != nil {
+		return fmt.Errorf("get playlist: %w", err)
+	}
+
 	ch.StreamedAt = time.Now().Unix()
 	ch.Sequence = 0
 	ch.InitSegment = nil
+	ch.AudioInitSegment = nil
+	ch.HasSeparateAudio = playlist.AudioPlaylistURL != ""
 
 	if err := ch.NextFile(); err != nil {
 		return fmt.Errorf("next file: %w", err)
@@ -102,51 +109,87 @@ func (ch *Channel) RecordStream(ctx context.Context, client *chaturbate.Client) 
 		}
 	}()
 
-	playlist, err := stream.GetPlaylist(ctx, ch.Config.Resolution, ch.Config.Framerate)
-	if err != nil {
-		return fmt.Errorf("get playlist: %w", err)
-	}
 	ch.RoomStatus = chaturbate.StatusPublic
 	ch.UpdateOnlineStatus(true) // after GetPlaylist succeeds
 
 	ch.Info("stream quality - resolution %dp (target: %dp), framerate %dfps (target: %dfps)", playlist.Resolution, ch.Config.Resolution, playlist.Framerate, ch.Config.Framerate)
+	if ch.HasSeparateAudio {
+		ch.Info("detected separate audio rendition, recording and muxing audio/video streams")
+	}
 
-	return playlist.WatchSegments(ctx, ch.HandleSegment, ch.HandleInitSegment)
+	return playlist.WatchAVSegments(ctx, ch.HandleSegment, ch.HandleInitSegment, ch.HandleAudioSegment, ch.HandleAudioInitSegment)
 }
 
 // HandleInitSegment stores the fMP4 init segment and reopens the file with the correct extension.
-func (ch *Channel) HandleInitSegment(initData []byte) {
+func (ch *Channel) HandleInitSegment(initData []byte) error {
 	ch.InitSegment = initData
 
 	if ch.File == nil {
-		return
+		return nil
 	}
 
 	oldName := ch.File.Name()
 	if err := ch.File.Close(); err != nil {
-		ch.Error("close file for rename: %s", err.Error())
-		return
+		return fmt.Errorf("close file for rename: %w", err)
 	}
+	ch.File = nil
 
 	newName := strings.TrimSuffix(oldName, filepath.Ext(oldName)) + ".mp4"
 	if err := os.Rename(oldName, newName); err != nil {
-		ch.Error("rename file to mp4: %s", err.Error())
-		return
+		return fmt.Errorf("rename file to mp4: %w", err)
 	}
 
 	file, err := os.OpenFile(newName, os.O_APPEND|os.O_WRONLY, 0777)
 	if err != nil {
-		ch.Error("reopen file as mp4: %s", err.Error())
-		return
+		_ = os.Remove(newName)
+		return fmt.Errorf("reopen file as mp4: %w", err)
 	}
 	ch.File = file
 
 	n, err := ch.File.Write(initData)
 	if err != nil {
-		ch.Error("write init segment: %s", err.Error())
-		return
+		_ = ch.File.Close()
+		ch.File = nil
+		_ = os.Remove(newName)
+		return fmt.Errorf("write init segment: %w", err)
 	}
 	ch.Filesize += n
+	return nil
+}
+
+// HandleAudioInitSegment stores the fMP4 audio init segment and reopens the audio file with the correct extension.
+func (ch *Channel) HandleAudioInitSegment(initData []byte) error {
+	ch.AudioInitSegment = initData
+
+	if ch.AudioFile == nil {
+		return nil
+	}
+
+	oldName := ch.AudioFile.Name()
+	if err := ch.AudioFile.Close(); err != nil {
+		return fmt.Errorf("close audio file for rename: %w", err)
+	}
+	ch.AudioFile = nil
+
+	newName := strings.TrimSuffix(oldName, filepath.Ext(oldName)) + ".mp4"
+	if err := os.Rename(oldName, newName); err != nil {
+		return fmt.Errorf("rename audio file to mp4: %w", err)
+	}
+
+	file, err := os.OpenFile(newName, os.O_APPEND|os.O_WRONLY, 0777)
+	if err != nil {
+		_ = os.Remove(newName)
+		return fmt.Errorf("reopen audio file as mp4: %w", err)
+	}
+	ch.AudioFile = file
+
+	if _, err := ch.AudioFile.Write(initData); err != nil {
+		_ = ch.AudioFile.Close()
+		ch.AudioFile = nil
+		_ = os.Remove(newName)
+		return fmt.Errorf("write audio init segment: %w", err)
+	}
+	return nil
 }
 
 // HandleSegment processes and writes segment data to a file.
@@ -173,6 +216,21 @@ func (ch *Channel) HandleSegment(b []byte, duration float64) error {
 		}
 		ch.Info("max filesize or duration exceeded, new file created: %s", ch.File.Name())
 		return nil
+	}
+	return nil
+}
+
+// HandleAudioSegment processes and writes audio segment data to a sidecar file.
+func (ch *Channel) HandleAudioSegment(b []byte, _ float64) error {
+	if ch.AudioFile == nil {
+		return nil
+	}
+	if ch.Config.IsPaused {
+		return retry.Unrecoverable(internal.ErrPaused)
+	}
+
+	if _, err := ch.AudioFile.Write(b); err != nil {
+		return fmt.Errorf("write audio file: %w", err)
 	}
 	return nil
 }

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -1,0 +1,67 @@
+package channel
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/teacat/chaturbate-dvr/entity"
+)
+
+func TestHandleInitSegmentRenamesFileToMP4(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ch := New(&entity.ChannelConfig{
+		Username: "alice",
+		Pattern:  filepath.Join(dir, "recording"),
+	})
+	ch.StreamedAt = 1
+
+	if err := ch.CreateNewFile(filepath.Join(dir, "recording")); err != nil {
+		t.Fatalf("CreateNewFile() error = %v", err)
+	}
+
+	initSegment := []byte("ftyp-test-moov")
+	if err := ch.HandleInitSegment(initSegment); err != nil {
+		t.Fatalf("HandleInitSegment() error = %v", err)
+	}
+	t.Cleanup(func() { _ = ch.Cleanup() })
+
+	if _, err := os.Stat(filepath.Join(dir, "recording.ts")); !os.IsNotExist(err) {
+		t.Fatalf("expected .ts file to be renamed, stat err = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "recording.mp4"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != string(initSegment) {
+		t.Fatalf("mp4 contents = %q, want %q", string(got), string(initSegment))
+	}
+}
+
+func TestCreateNewFileWritesInitSegmentForRotatedFMP4Files(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	initSegment := []byte("ftyp-test-moov")
+	ch := New(&entity.ChannelConfig{
+		Username: "alice",
+		Pattern:  filepath.Join(dir, "recording"),
+	})
+	ch.InitSegment = initSegment
+
+	if err := ch.CreateNewFile(filepath.Join(dir, "rotated")); err != nil {
+		t.Fatalf("CreateNewFile() error = %v", err)
+	}
+	t.Cleanup(func() { _ = ch.Cleanup() })
+
+	got, err := os.ReadFile(filepath.Join(dir, "rotated.mp4"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != string(initSegment) {
+		t.Fatalf("mp4 contents = %q, want %q", string(got), string(initSegment))
+	}
+}

--- a/chaturbate/chaturbate.go
+++ b/chaturbate/chaturbate.go
@@ -274,8 +274,11 @@ func resolveURL(baseURL, ref string) string {
 // WatchHandler is a function type that processes video segments.
 type WatchHandler func(b []byte, duration float64) error
 
+// InitHandler is called once when an init segment (fMP4 moov atom) is detected.
+type InitHandler func(initData []byte)
+
 // WatchSegments continuously fetches and processes video segments.
-func (p *Playlist) WatchSegments(ctx context.Context, handler WatchHandler) error {
+func (p *Playlist) WatchSegments(ctx context.Context, handler WatchHandler, initHandler InitHandler) error {
 	var (
 		client      = internal.NewReq()
 		lastSeq     = -1
@@ -312,8 +315,8 @@ func (p *Playlist) WatchSegments(ctx context.Context, handler WatchHandler) erro
 			if initErr != nil {
 				return fmt.Errorf("fetch init segment: %w", initErr)
 			}
-			if err := handler(initData, 0); err != nil {
-				return fmt.Errorf("handler init: %w", err)
+			if initHandler != nil {
+				initHandler(initData)
 			}
 			initWritten = true
 		}

--- a/chaturbate/chaturbate.go
+++ b/chaturbate/chaturbate.go
@@ -184,16 +184,18 @@ func ParsePlaylist(resp, hlsSource string, resolution, framerate int) (*Playlist
 
 // Playlist represents an HLS playlist containing variant streams.
 type Playlist struct {
-	PlaylistURL string
-	RootURL     string
-	Resolution  int
-	Framerate   int
+	PlaylistURL      string
+	AudioPlaylistURL string
+	RootURL          string
+	Resolution       int
+	Framerate        int
 }
 
 // Resolution represents a video resolution and its corresponding framerate.
 type Resolution struct {
-	Framerate map[int]string // [framerate]url
-	Width     int
+	Framerate    map[int]string // [framerate]url
+	Width        int
+	Alternatives []*m3u8.Alternative
 }
 
 // PickPlaylist selects the best matching variant stream based on resolution and framerate.
@@ -215,7 +217,7 @@ func PickPlaylist(masterPlaylist *m3u8.MasterPlaylist, baseURL string, resolutio
 			framerateVal = 60
 		}
 		if _, exists := resolutions[width]; !exists {
-			resolutions[width] = &Resolution{Framerate: map[int]string{}, Width: width}
+			resolutions[width] = &Resolution{Framerate: map[int]string{}, Width: width, Alternatives: v.Alternatives}
 		}
 		resolutions[width].Framerate[framerateVal] = v.URI
 	}
@@ -239,6 +241,7 @@ func PickPlaylist(masterPlaylist *m3u8.MasterPlaylist, baseURL string, resolutio
 	var (
 		finalResolution = variant.Width
 		finalFramerate  = framerate
+		audioPlaylist   string
 	)
 	// Select the desired framerate, or fallback to the first available framerate
 	playlistURL, exists := variant.Framerate[framerate]
@@ -250,11 +253,22 @@ func PickPlaylist(masterPlaylist *m3u8.MasterPlaylist, baseURL string, resolutio
 		}
 	}
 
+	for _, alt := range variant.Alternatives {
+		if alt == nil || alt.Type != "AUDIO" || alt.URI == "" {
+			continue
+		}
+		audioPlaylist = resolveURL(baseURL, alt.URI)
+		if alt.Default {
+			break
+		}
+	}
+
 	return &Playlist{
-		PlaylistURL: resolveURL(baseURL, playlistURL),
-		RootURL:     baseURL,
-		Resolution:  finalResolution,
-		Framerate:   finalFramerate,
+		PlaylistURL:      resolveURL(baseURL, playlistURL),
+		AudioPlaylistURL: audioPlaylist,
+		RootURL:          baseURL,
+		Resolution:       finalResolution,
+		Framerate:        finalFramerate,
 	}, nil
 }
 
@@ -275,86 +289,102 @@ func resolveURL(baseURL, ref string) string {
 type WatchHandler func(b []byte, duration float64) error
 
 // InitHandler is called once when an init segment (fMP4 moov atom) is detected.
-type InitHandler func(initData []byte)
+type InitHandler func(initData []byte) error
 
 // WatchSegments continuously fetches and processes video segments.
 func (p *Playlist) WatchSegments(ctx context.Context, handler WatchHandler, initHandler InitHandler) error {
+	return p.WatchAVSegments(ctx, handler, initHandler, nil, nil)
+}
+
+// WatchAVSegments continuously fetches and processes video segments, and optional separate audio segments.
+func (p *Playlist) WatchAVSegments(ctx context.Context, handler WatchHandler, initHandler InitHandler, audioHandler WatchHandler, audioInitHandler InitHandler) error {
 	var (
-		client      = internal.NewReq()
-		lastSeq     = -1
-		initWritten = false
+		client           = internal.NewReq()
+		lastSeq          = -1
+		initWritten      = false
+		audioLastSeq     = -1
+		audioInitWritten = false
 	)
 
 	for {
-		// Fetch the latest playlist
-		resp, err := client.Get(ctx, p.PlaylistURL)
-		if err != nil {
-			return fmt.Errorf("get playlist: %w", err)
+		if err := p.processMediaPlaylist(ctx, client, p.PlaylistURL, handler, initHandler, &lastSeq, &initWritten); err != nil {
+			return fmt.Errorf("video: %w", err)
 		}
-		pl, _, err := m3u8.DecodeFrom(strings.NewReader(resp), true)
-		if err != nil {
-			return fmt.Errorf("decode from: %w", err)
-		}
-		playlist, ok := pl.(*m3u8.MediaPlaylist)
-		if !ok {
-			return fmt.Errorf("cast to media playlist")
-		}
-
-		// Handle init segment for fMP4/LL-HLS format (EXT-X-MAP)
-		if !initWritten && playlist.Map != nil && playlist.Map.URI != "" {
-			initURL := resolveURL(p.PlaylistURL, playlist.Map.URI)
-			initData, initErr := retry.DoWithData(
-				func() ([]byte, error) {
-					return client.GetBytes(ctx, initURL)
-				},
-				retry.Context(ctx),
-				retry.Attempts(3),
-				retry.Delay(600*time.Millisecond),
-				retry.DelayType(retry.FixedDelay),
-			)
-			if initErr != nil {
-				return fmt.Errorf("fetch init segment: %w", initErr)
-			}
-			if initHandler != nil {
-				initHandler(initData)
-			}
-			initWritten = true
-		}
-
-		// Process new segments
-		for _, v := range playlist.Segments {
-			if v == nil {
-				continue
-			}
-			seq := internal.SegmentSeq(v.URI)
-			if seq == -1 || seq <= lastSeq {
-				continue
-			}
-			lastSeq = seq
-
-			// Fetch segment data with retry mechanism
-			segmentURL := resolveURL(p.PlaylistURL, v.URI)
-			pipeline := func() ([]byte, error) {
-				return client.GetBytes(ctx, segmentURL)
-			}
-
-			resp, err := retry.DoWithData(
-				pipeline,
-				retry.Context(ctx),
-				retry.Attempts(3),
-				retry.Delay(600*time.Millisecond),
-				retry.DelayType(retry.FixedDelay),
-			)
-			if err != nil {
-				break
-			}
-
-			// Process the segment using the provided handler
-			if err := handler(resp, v.Duration); err != nil {
-				return fmt.Errorf("handler: %w", err)
+		if p.AudioPlaylistURL != "" {
+			if err := p.processMediaPlaylist(ctx, client, p.AudioPlaylistURL, audioHandler, audioInitHandler, &audioLastSeq, &audioInitWritten); err != nil {
+				return fmt.Errorf("audio: %w", err)
 			}
 		}
 
 		<-time.After(1 * time.Second) // time.Duration(playlist.TargetDuration)
 	}
+}
+
+func (p *Playlist) processMediaPlaylist(ctx context.Context, client *internal.Req, playlistURL string, handler WatchHandler, initHandler InitHandler, lastSeq *int, initWritten *bool) error {
+	resp, err := client.Get(ctx, playlistURL)
+	if err != nil {
+		return fmt.Errorf("get playlist: %w", err)
+	}
+	pl, _, err := m3u8.DecodeFrom(strings.NewReader(resp), true)
+	if err != nil {
+		return fmt.Errorf("decode from: %w", err)
+	}
+	playlist, ok := pl.(*m3u8.MediaPlaylist)
+	if !ok {
+		return fmt.Errorf("cast to media playlist")
+	}
+
+	if !*initWritten && playlist.Map != nil && playlist.Map.URI != "" {
+		initURL := resolveURL(playlistURL, playlist.Map.URI)
+		initData, initErr := retry.DoWithData(
+			func() ([]byte, error) {
+				return client.GetBytes(ctx, initURL)
+			},
+			retry.Context(ctx),
+			retry.Attempts(3),
+			retry.Delay(600*time.Millisecond),
+			retry.DelayType(retry.FixedDelay),
+		)
+		if initErr != nil {
+			return fmt.Errorf("fetch init segment: %w", initErr)
+		}
+		if initHandler != nil {
+			if err := initHandler(initData); err != nil {
+				return fmt.Errorf("handler init: %w", err)
+			}
+		}
+		*initWritten = true
+	}
+
+	for _, v := range playlist.Segments {
+		if v == nil {
+			continue
+		}
+		seq := internal.SegmentSeq(v.URI)
+		if seq == -1 || seq <= *lastSeq {
+			continue
+		}
+		*lastSeq = seq
+
+		segmentURL := resolveURL(playlistURL, v.URI)
+		resp, err := retry.DoWithData(
+			func() ([]byte, error) {
+				return client.GetBytes(ctx, segmentURL)
+			},
+			retry.Context(ctx),
+			retry.Attempts(3),
+			retry.Delay(600*time.Millisecond),
+			retry.DelayType(retry.FixedDelay),
+		)
+		if err != nil {
+			break
+		}
+		if handler != nil {
+			if err := handler(resp, v.Duration); err != nil {
+				return fmt.Errorf("handler: %w", err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/chaturbate/chaturbate_test.go
+++ b/chaturbate/chaturbate_test.go
@@ -1,0 +1,38 @@
+package chaturbate
+
+import (
+	"testing"
+
+	"github.com/grafov/m3u8"
+)
+
+func TestPickPlaylistIncludesDefaultAudioRendition(t *testing.T) {
+	t.Parallel()
+
+	master := &m3u8.MasterPlaylist{
+		Variants: []*m3u8.Variant{
+			{
+				URI: "video.m3u8",
+				VariantParams: m3u8.VariantParams{
+					Resolution: "1920x1080",
+					FrameRate:  60,
+					Audio:      "audio-main",
+					Alternatives: []*m3u8.Alternative{
+						{Type: "AUDIO", GroupId: "audio-main", URI: "audio-en.m3u8", Name: "English", Default: true},
+					},
+				},
+			},
+		},
+	}
+
+	playlist, err := PickPlaylist(master, "https://example.com/master.m3u8", 1080, 60)
+	if err != nil {
+		t.Fatalf("PickPlaylist() error = %v", err)
+	}
+	if got, want := playlist.PlaylistURL, "https://example.com/video.m3u8"; got != want {
+		t.Fatalf("PlaylistURL = %q, want %q", got, want)
+	}
+	if got, want := playlist.AudioPlaylistURL, "https://example.com/audio-en.m3u8"; got != want {
+		t.Fatalf("AudioPlaylistURL = %q, want %q", got, want)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main() {
 			},
 			&cli.BoolFlag{
 				Name:  "compress",
-				Usage: "Compress .ts files to .mkv using ffmpeg after recording (auto-enabled if ffmpeg is installed)",
+				Usage: "Compress recorded files (.ts or .mp4) to .mkv using ffmpeg after recording (auto-enabled if ffmpeg is installed)",
 				Value: false,
 			},
 		},

--- a/router/view/templates/index.html
+++ b/router/view/templates/index.html
@@ -240,7 +240,7 @@
                             <input type="checkbox" name="compress" value="true" {{ if .Config.Compress }}checked{{ end }} class="accent-zinc-900" />
                             Compress to MKV after recording (requires ffmpeg)
                         </label>
-                        <p class="text-xs text-zinc-400 mt-1 ml-6">Convert .ts files to .mkv format using stream copy. Original .ts files will be deleted.</p>
+                        <p class="text-xs text-zinc-400 mt-1 ml-6">Convert recorded .ts or .mp4 files to .mkv with ffmpeg. Original source files will be deleted.</p>
                     </div>
                 </div>
                 <div class="flex justify-end gap-2 px-6 py-4 border-t border-zinc-100">


### PR DESCRIPTION
## Summary

Fixes #5 — LL-HLS streams use fMP4 (fragmented MP4) segments, but the recorder was saving them with a `.ts` extension. This caused:
- **No audio track** — media players tried to parse fMP4 data as MPEG-TS
- **Incorrect duration** — fMP4 timestamps misinterpreted by MPEG-TS parsers  
- **File corruption** — Windows Explorer couldn't read file metadata

## Changes

- Detect fMP4 format when init segment (EXT-X-MAP) is present, use `.mp4` extension instead of `.ts`
- Store init segment (moov atom) on the channel and re-write it when file rotation creates new files, so every output file is independently playable
- Fix compress feature to handle both `.ts` and `.mp4` source files

## Test plan

- [x] Record a channel using LL-HLS — verify output is `.mp4` with audio
- [ ] Record a legacy HLS channel — verify output remains `.ts`  
- [ ] Test file rotation (max filesize/duration) — verify each split file plays independently
- [ ] Test compress feature with `.mp4` input