### PR TITLE
fix: native mp4 mux fallback for LL-HLS separate audio/video tracks

### DIFF
--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -2,13 +2,21 @@ package channel
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 
+	"github.com/Eyevinn/mp4ff/mp4"
 	"github.com/teacat/chaturbate-dvr/internal"
+)
+
+// Track IDs for muxed output
+const (
+	videoTrackID uint32 = 1
+	audioTrackID uint32 = 2
 )
 
 // GPU encoder detection cache
@@ -140,6 +148,8 @@ func (ch *Channel) MuxAV(videoPath, audioPath, outputPath string) error {
 		"-map", "0:v:0",
 		"-map", "1:a:0",
 		"-c", "copy",
+		"-copyts",
+		"-avoid_negative_ts", "make_zero",
 		outputPath,
 	}
 
@@ -159,3 +169,163 @@ func (ch *Channel) MuxAV(videoPath, audioPath, outputPath string) error {
 	ch.Info("mux: combined %s + %s -> %s", filepath.Base(videoPath), filepath.Base(audioPath), filepath.Base(outputPath))
 	return nil
 }
+
+// MuxAVNative combines separate fragmented MP4 audio/video tracks without ffmpeg.
+func (ch *Channel) MuxAVNative(videoPath, audioPath, outputPath string) error {
+	videoFile, err := mp4.ReadMP4File(videoPath)
+	if err != nil {
+		return fmt.Errorf("decode video mp4: %w", err)
+	}
+	audioFile, err := mp4.ReadMP4File(audioPath)
+	if err != nil {
+		return fmt.Errorf("decode audio mp4: %w", err)
+	}
+
+	outFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("create mux output: %w", err)
+	}
+	defer outFile.Close()
+
+	if err := writeCombinedFragmentedMP4(outFile, videoFile, audioFile); err != nil {
+		outFile.Close()
+		os.Remove(outputPath)
+		return fmt.Errorf("native mux audio/video: %w", err)
+	}
+
+	ch.Info("mux: combined %s + %s -> %s (native)", filepath.Base(videoPath), filepath.Base(audioPath), filepath.Base(outputPath))
+	return nil
+}
+
+func writeCombinedFragmentedMP4(w io.Writer, videoFile, audioFile *mp4.File) error {
+	_, videoTrex, err := sourceTrack(videoFile, "vide")
+	if err != nil {
+		return fmt.Errorf("load video track: %w", err)
+	}
+	audioTrack, audioTrex, err := sourceTrack(audioFile, "soun")
+	if err != nil {
+		return fmt.Errorf("load audio track: %w", err)
+	}
+
+	ftyp := videoFile.Init.Ftyp
+	moov := videoFile.Init.Moov
+	if len(moov.Traks) != 1 || moov.Mvex == nil || len(moov.Mvex.Trexs) != 1 {
+		return fmt.Errorf("expected single-track video init")
+	}
+
+	moov.Traks[0].Tkhd.TrackID = videoTrackID
+	moov.Mvex.Trexs[0].TrackID = videoTrackID
+
+	audioTrack.Tkhd.TrackID = audioTrackID
+	audioTrex.TrackID = audioTrackID
+
+	moov.AddChild(audioTrack)
+	moov.Mvex.AddChild(audioTrex)
+	moov.Mvhd.NextTrackID = audioTrackID + 1
+
+	out := mp4.NewFile()
+	out.AddChild(ftyp, 0)
+	out.AddChild(moov, ftyp.Size())
+
+	segments, err := combineTrackFragments(collectFragments(videoFile), videoTrex, collectFragments(audioFile), audioTrex)
+	if err != nil {
+		return err
+	}
+	for _, segment := range segments {
+		out.AddMediaSegment(segment)
+	}
+
+	return out.Encode(w)
+}
+
+func sourceTrack(file *mp4.File, handlerType string) (*mp4.TrakBox, *mp4.TrexBox, error) {
+	if file == nil || file.Init == nil || file.Init.Moov == nil {
+		return nil, nil, fmt.Errorf("missing init segment")
+	}
+	if len(file.Init.Moov.Traks) != 1 {
+		return nil, nil, fmt.Errorf("expected exactly one track, got %d", len(file.Init.Moov.Traks))
+	}
+
+	trak := file.Init.Moov.Traks[0]
+	if trak == nil || trak.Tkhd == nil || trak.Mdia == nil || trak.Mdia.Hdlr == nil {
+		return nil, nil, fmt.Errorf("invalid track metadata")
+	}
+	if trak.Mdia.Hdlr.HandlerType != handlerType {
+		return nil, nil, fmt.Errorf("expected %s track, got %s", handlerType, trak.Mdia.Hdlr.HandlerType)
+	}
+	if file.Init.Moov.Mvex == nil {
+		return nil, nil, fmt.Errorf("missing mvex")
+	}
+
+	trex, ok := file.Init.Moov.Mvex.GetTrex(trak.Tkhd.TrackID)
+	if !ok || trex == nil {
+		return nil, nil, fmt.Errorf("missing trex for track %d", trak.Tkhd.TrackID)
+	}
+
+	return trak, trex, nil
+}
+
+func combineTrackFragments(videoFragments []*mp4.Fragment, videoTrex *mp4.TrexBox, audioFragments []*mp4.Fragment, audioTrex *mp4.TrexBox) ([]*mp4.MediaSegment, error) {
+	maxFragments := len(videoFragments)
+	if len(audioFragments) > maxFragments {
+		maxFragments = len(audioFragments)
+	}
+	if maxFragments == 0 {
+		return nil, fmt.Errorf("missing media fragments")
+	}
+
+	segments := make([]*mp4.MediaSegment, 0, maxFragments)
+	for i := 0; i < maxFragments; i++ {
+		trackIDs := make([]uint32, 0, 2)
+		if i < len(videoFragments) {
+			trackIDs = append(trackIDs, videoTrackID)
+		}
+		if i < len(audioFragments) {
+			trackIDs = append(trackIDs, audioTrackID)
+		}
+
+		fragment, err := mp4.CreateMultiTrackFragment(uint32(i+1), trackIDs)
+		if err != nil {
+			return nil, fmt.Errorf("create fragment %d: %w", i, err)
+		}
+
+		if i < len(videoFragments) {
+			if err := appendFragmentSamples(fragment, videoFragments[i], videoTrex, videoTrackID); err != nil {
+				return nil, fmt.Errorf("append video fragment %d: %w", i, err)
+			}
+		}
+		if i < len(audioFragments) {
+			if err := appendFragmentSamples(fragment, audioFragments[i], audioTrex, audioTrackID); err != nil {
+				return nil, fmt.Errorf("append audio fragment %d: %w", i, err)
+			}
+		}
+
+		segment := mp4.NewMediaSegmentWithoutStyp()
+		segment.AddFragment(fragment)
+		segments = append(segments, segment)
+	}
+
+	return segments, nil
+}
+
+func appendFragmentSamples(dst, src *mp4.Fragment, trex *mp4.TrexBox, trackID uint32) error {
+	fullSamples, err := src.GetFullSamples(trex)
+	if err != nil {
+		return err
+	}
+	for _, sample := range fullSamples {
+		if err := dst.AddFullSampleToTrack(sample, trackID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func collectFragments(file *mp4.File) []*mp4.Fragment {
+	var fragments []*mp4.Fragment
+	for _, segment := range file.Segments {
+		fragments = append(fragments, segment.Fragments...)
+	}
+	return fragments
+}
+

--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -207,6 +207,14 @@ func writeCombinedFragmentedMP4(w io.Writer, videoFile, audioFile *mp4.File) err
 		return fmt.Errorf("load audio track: %w", err)
 	}
 
+	// Combine fragments BEFORE reassigning track IDs — GetFullSamples
+	// matches source traf boxes by trex.TrackID, which must still hold
+	// the original value from the source file.
+	segments, err := combineTrackFragments(collectFragments(videoFile), videoTrex, collectFragments(audioFile), audioTrex)
+	if err != nil {
+		return err
+	}
+
 	ftyp := videoFile.Init.Ftyp
 	moov := videoFile.Init.Moov
 	if len(moov.Traks) != 1 || moov.Mvex == nil || len(moov.Mvex.Trexs) != 1 {
@@ -226,11 +234,6 @@ func writeCombinedFragmentedMP4(w io.Writer, videoFile, audioFile *mp4.File) err
 	out := mp4.NewFile()
 	out.AddChild(ftyp, 0)
 	out.AddChild(moov, ftyp.Size())
-
-	segments, err := combineTrackFragments(collectFragments(videoFile), videoTrex, collectFragments(audioFile), audioTrex)
-	if err != nil {
-		return err
-	}
 	for _, segment := range segments {
 		out.AddMediaSegment(segment)
 	}

--- a/channel/channel_file.go
+++ b/channel/channel_file.go
@@ -81,7 +81,10 @@ func (ch *Channel) Cleanup() error {
 
 		finalOutput := currentFilename + ".mp4"
 		if err := ch.MuxAV(videoFilename, audioFilename, finalOutput); err != nil {
-			return err
+			ch.Info("mux: ffmpeg mux failed, trying native fallback: %s", err.Error())
+			if nativeErr := ch.MuxAVNative(videoFilename, audioFilename, finalOutput); nativeErr != nil {
+				return fmt.Errorf("mux audio/video: %w", nativeErr)
+			}
 		}
 		_ = os.Remove(videoFilename)
 		_ = os.Remove(audioFilename)

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -1,11 +1,13 @@
 package channel
 
 import (
+	"bytes"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/Eyevinn/mp4ff/mp4"
 	"github.com/teacat/chaturbate-dvr/entity"
 	"github.com/teacat/chaturbate-dvr/server"
 )
@@ -84,9 +86,46 @@ func TestCreateNewFileWritesInitSegmentForRotatedFMP4Files(t *testing.T) {
 	}
 }
 
+// buildFragmentedMP4 creates a minimal valid fragmented MP4 in memory with one track and one sample.
+func buildFragmentedMP4(t *testing.T, mediaType string, timescale uint32, sampleData []byte) []byte {
+	t.Helper()
+
+	init := mp4.CreateEmptyInit()
+	init.AddEmptyTrack(timescale, mediaType, "und")
+	if err := init.TweakSingleTrakLive(); err != nil {
+		t.Fatalf("TweakSingleTrakLive(%s) error = %v", mediaType, err)
+	}
+
+	seg := mp4.NewMediaSegmentWithoutStyp()
+	frag, err := mp4.CreateFragment(1, 1)
+	if err != nil {
+		t.Fatalf("CreateFragment(%s) error = %v", mediaType, err)
+	}
+	if err := frag.AddFullSampleToTrack(mp4.FullSample{
+		Sample:     mp4.Sample{Flags: mp4.SyncSampleFlags, Dur: timescale, Size: uint32(len(sampleData))},
+		DecodeTime: 0,
+		Data:       sampleData,
+	}, 1); err != nil {
+		t.Fatalf("AddFullSampleToTrack(%s) error = %v", mediaType, err)
+	}
+	seg.AddFragment(frag)
+
+	var buf bytes.Buffer
+	if err := init.Encode(&buf); err != nil {
+		t.Fatalf("encode init(%s) error = %v", mediaType, err)
+	}
+	if err := seg.Encode(&buf); err != nil {
+		t.Fatalf("encode segment(%s) error = %v", mediaType, err)
+	}
+	return buf.Bytes()
+}
+
 func TestCleanupNativeMuxesSeparateTracksWhenFFmpegUnavailable(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("PATH", dir)
+
+	videoMP4 := buildFragmentedMP4(t, "video", 90000, []byte{0x00, 0x00, 0x00, 0x01, 0x67}) // fake NAL unit
+	audioMP4 := buildFragmentedMP4(t, "audio", 44100, []byte{0xFF, 0xF1})                    // fake AAC frame
 
 	base := filepath.Join(dir, "recording")
 	ch := New(&entity.ChannelConfig{
@@ -95,18 +134,11 @@ func TestCleanupNativeMuxesSeparateTracksWhenFFmpegUnavailable(t *testing.T) {
 	})
 	ch.HasSeparateAudio = true
 	ch.CurrentFilename = base
-	ch.InitSegment = []byte("video-init")
-	ch.AudioInitSegment = []byte("audio-init")
+	ch.InitSegment = videoMP4
+	ch.AudioInitSegment = audioMP4
 
 	if err := ch.CreateNewFile(base); err != nil {
 		t.Fatalf("CreateNewFile() error = %v", err)
-	}
-
-	if _, err := ch.File.Write([]byte("video-fragment")); err != nil {
-		t.Fatalf("write video fragment error = %v", err)
-	}
-	if _, err := ch.AudioFile.Write([]byte("audio-fragment")); err != nil {
-		t.Fatalf("write audio fragment error = %v", err)
 	}
 
 	if err := ch.Cleanup(); err != nil {

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -145,7 +145,8 @@ func TestCleanupNativeMuxesSeparateTracksWhenFFmpegUnavailable(t *testing.T) {
 		t.Fatalf("Cleanup() error = %v", err)
 	}
 
-	info, err := os.Stat(base + ".mp4")
+	outputPath := base + ".mp4"
+	info, err := os.Stat(outputPath)
 	if err != nil {
 		t.Fatalf("expected final mp4, stat err = %v", err)
 	}
@@ -157,6 +158,15 @@ func TestCleanupNativeMuxesSeparateTracksWhenFFmpegUnavailable(t *testing.T) {
 	}
 	if _, err := os.Stat(base + ".audio.mp4"); !os.IsNotExist(err) {
 		t.Fatalf("expected audio sidecar removed, stat err = %v", err)
+	}
+
+	// Verify the muxed output contains both video and audio tracks
+	muxed, err := mp4.ReadMP4File(outputPath)
+	if err != nil {
+		t.Fatalf("ReadMP4File() error = %v", err)
+	}
+	if len(muxed.Init.Moov.Traks) != 2 {
+		t.Fatalf("expected 2 tracks in muxed output, got %d", len(muxed.Init.Moov.Traks))
 	}
 }
 

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -1,12 +1,30 @@
 package channel
 
 import (
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/teacat/chaturbate-dvr/entity"
+	"github.com/teacat/chaturbate-dvr/server"
 )
+
+type noopManager struct{}
+
+func (noopManager) CreateChannel(*entity.ChannelConfig, bool) error { return nil }
+func (noopManager) StopChannel(string) error                        { return nil }
+func (noopManager) PauseChannel(string) error                       { return nil }
+func (noopManager) ResumeChannel(string) error                      { return nil }
+func (noopManager) ChannelInfo() []*entity.ChannelInfo              { return nil }
+func (noopManager) Publish(string, *entity.ChannelInfo)             {}
+func (noopManager) Subscriber(http.ResponseWriter, *http.Request)   {}
+func (noopManager) LoadConfig() error                               { return nil }
+func (noopManager) SaveConfig() error                               { return nil }
+
+func init() {
+	server.Manager = noopManager{}
+}
 
 func TestHandleInitSegmentRenamesFileToMP4(t *testing.T) {
 	t.Parallel()
@@ -63,5 +81,72 @@ func TestCreateNewFileWritesInitSegmentForRotatedFMP4Files(t *testing.T) {
 	}
 	if string(got) != string(initSegment) {
 		t.Fatalf("mp4 contents = %q, want %q", string(got), string(initSegment))
+	}
+}
+
+func TestCleanupNativeMuxesSeparateTracksWhenFFmpegUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+
+	base := filepath.Join(dir, "recording")
+	ch := New(&entity.ChannelConfig{
+		Username: "alice",
+		Pattern:  base,
+	})
+	ch.HasSeparateAudio = true
+	ch.CurrentFilename = base
+	ch.InitSegment = []byte("video-init")
+	ch.AudioInitSegment = []byte("audio-init")
+
+	if err := ch.CreateNewFile(base); err != nil {
+		t.Fatalf("CreateNewFile() error = %v", err)
+	}
+
+	if _, err := ch.File.Write([]byte("video-fragment")); err != nil {
+		t.Fatalf("write video fragment error = %v", err)
+	}
+	if _, err := ch.AudioFile.Write([]byte("audio-fragment")); err != nil {
+		t.Fatalf("write audio fragment error = %v", err)
+	}
+
+	if err := ch.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	info, err := os.Stat(base + ".mp4")
+	if err != nil {
+		t.Fatalf("expected final mp4, stat err = %v", err)
+	}
+	if info.Size() <= 0 {
+		t.Fatalf("expected final mp4 to be non-empty, size = %d", info.Size())
+	}
+	if _, err := os.Stat(base + ".video.mp4"); !os.IsNotExist(err) {
+		t.Fatalf("expected video sidecar removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(base + ".audio.mp4"); !os.IsNotExist(err) {
+		t.Fatalf("expected audio sidecar removed, stat err = %v", err)
+	}
+}
+
+func TestCreateNewFileKeepsLegacyHLSAsTS(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	base := filepath.Join(dir, "legacy")
+	ch := New(&entity.ChannelConfig{
+		Username: "alice",
+		Pattern:  base,
+	})
+
+	if err := ch.CreateNewFile(base); err != nil {
+		t.Fatalf("CreateNewFile() error = %v", err)
+	}
+	t.Cleanup(func() { _ = ch.Cleanup() })
+
+	if _, err := os.Stat(base + ".ts"); err != nil {
+		t.Fatalf("expected legacy ts output, stat err = %v", err)
+	}
+	if _, err := os.Stat(base + ".mp4"); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy mp4 output to not exist, stat err = %v", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/teacat/chaturbate-dvr
 go 1.23.0
 
 require (
+	github.com/Eyevinn/mp4ff v0.51.0
 	github.com/avast/retry-go/v4 v4.6.1
 	github.com/gin-gonic/gin v1.10.0
 	github.com/grafov/m3u8 v0.12.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Eyevinn/mp4ff v0.51.0 h1:ZYdHFXEcB3kJkCeCHMHl/tbCm64FJsD2XOU0Sj+ME2M=
+github.com/Eyevinn/mp4ff v0.51.0/go.mod h1:hJNUUqOBryLAzUW9wpCJyw2HaI+TCd2rUPhafoS5lgg=
 github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=
 github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
@@ -27,6 +29,7 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.20.0 h1:K9ISHbSaI0lyB2eWMPJo+kOS/FBExVwjEviJTixqxL8=
 github.com/go-playground/validator/v10 v10.20.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=


### PR DESCRIPTION
## Summary

- Add native fragmented MP4 muxing using `mp4ff` library as fallback when ffmpeg is unavailable
- Fix audio/video sync issues by adding `-copyts -avoid_negative_ts make_zero` to ffmpeg mux
- Cleanup() now: try ffmpeg first, fall back to native mux on failure, clean up partial output on error

## Context

LL-HLS streams on Chaturbate use separate audio and video renditions. During recording, these are written to separate `.video.mp4` and `.audio.mp4` files, then combined on cleanup. Previously this required ffmpeg — users without it got an error and were left with split files. The ffmpeg mux also lacked timestamp correction flags, causing audio/video desync.

## Changes

- `channel/channel_compress.go`: Add `MuxAVNative()` using `mp4ff` library, add sync flags to `MuxAV()`
- `channel/channel_file.go`: Add fallback from ffmpeg to native mux in `Cleanup()`
- `channel/channel_record_test.go`: Tests with valid fragmented MP4 fixtures

## Test plan

- [x] `go test ./...` passes
- [x] `go build` succeeds
- [x] Record LL-HLS stream with ffmpeg installed — verify single `.mp4` output with synced audio
- [x] Record LL-HLS stream without ffmpeg — verify native fallback produces valid `.mp4`
- [ ] Record legacy HLS stream — verify `.ts` output unchanged

Closes #9