### PR TITLE
fix: LL-HLS recording bugs (A/V desync, silent drop, data loss)

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -37,6 +37,7 @@ type Channel struct {
 	InitSegment      []byte // fMP4 video init segment for LL-HLS streams
 	AudioInitSegment []byte // fMP4 audio init segment for LL-HLS streams
 	HasSeparateAudio bool
+	switchRequested  bool // set by HandleSegment, consumed by OnPollComplete
 }
 
 // New creates a new channel instance with the given manager and configuration.

--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -143,19 +143,21 @@ func (ch *Channel) CompressFile(srcPath string) {
 
 // MuxAV combines separate video and audio source files into a single MP4 container.
 func (ch *Channel) MuxAV(videoPath, audioPath, outputPath string) error {
-	// LL-HLS delivers video and audio on independent playlists, so their first
-	// fragment TFDTs rarely line up (audio commonly starts 1-3 seconds later
-	// than video in the live timeline). Preserving those absolute timestamps
-	// with -copyts made both streams keep their offset in the output, leaving
-	// trailing audio past the end of the video track (player freezes on the
-	// last frame while audio keeps playing).
+	// LL-HLS fragments are timestamped against an absolute presentation
+	// timeline (TFDT), so the raw video and audio fragments only line up
+	// if we preserve those timestamps with -copyts. Dropping -copyts made
+	// ffmpeg renormalize each input to start at zero independently — which
+	// is fine when the first fetched video/audio segments happened to
+	// represent the same wall-clock moment, but when they differ (very
+	// common on the very first poll of a live stream), the sound from the
+	// later audio segment ends up playing against the earlier video
+	// content, so users hear audio running seconds ahead of video.
 	//
-	// Instead, let ffmpeg normalize each input to start at zero, add
-	// -shortest so a stray partial segment on one side cannot extend the
-	// combined duration past the point where both tracks have real samples,
-	// and keep -avoid_negative_ts make_zero so H.264 B-frame reordering
-	// (which produces negative DTS on the first packet) cannot let audio
-	// appear ahead of video on strict players.
+	// Keep -copyts for content alignment, -shortest so a stray partial
+	// segment on one side cannot extend the combined duration past the
+	// point both tracks have real samples, and -avoid_negative_ts
+	// make_zero so H.264 B-frame reordering (negative DTS on the first
+	// packet) cannot desync the output on strict players.
 	args := []string{
 		"-y",
 		"-i", videoPath,
@@ -163,6 +165,7 @@ func (ch *Channel) MuxAV(videoPath, audioPath, outputPath string) error {
 		"-map", "0:v:0",
 		"-map", "1:a:0",
 		"-c", "copy",
+		"-copyts",
 		"-shortest",
 		"-avoid_negative_ts", "make_zero",
 		outputPath,

--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -189,7 +189,8 @@ func (ch *Channel) MuxAVNative(videoPath, audioPath, outputPath string) error {
 	}
 	defer outFile.Close()
 
-	if err := writeCombinedFragmentedMP4(outFile, videoFile, audioFile); err != nil {
+	warn := func(msg string) { ch.Info("mux: %s", msg) }
+	if err := writeCombinedFragmentedMP4(outFile, videoFile, audioFile, warn); err != nil {
 		outFile.Close()
 		os.Remove(outputPath)
 		return fmt.Errorf("native mux audio/video: %w", err)
@@ -199,7 +200,7 @@ func (ch *Channel) MuxAVNative(videoPath, audioPath, outputPath string) error {
 	return nil
 }
 
-func writeCombinedFragmentedMP4(w io.Writer, videoFile, audioFile *mp4.File) error {
+func writeCombinedFragmentedMP4(w io.Writer, videoFile, audioFile *mp4.File, warn func(string)) error {
 	_, videoTrex, err := sourceTrack(videoFile, "vide")
 	if err != nil {
 		return fmt.Errorf("load video track: %w", err)
@@ -212,7 +213,12 @@ func writeCombinedFragmentedMP4(w io.Writer, videoFile, audioFile *mp4.File) err
 	// Combine fragments BEFORE reassigning track IDs — GetFullSamples
 	// matches source traf boxes by trex.TrackID, which must still hold
 	// the original value from the source file.
-	segments, err := combineTrackFragments(collectFragments(videoFile), videoTrex, collectFragments(audioFile), audioTrex)
+	videoFragments := collectFragments(videoFile)
+	audioFragments := collectFragments(audioFile)
+	if warn != nil && len(videoFragments) != len(audioFragments) {
+		warn(fmt.Sprintf("fragment count mismatch (video=%d, audio=%d); output may have track-solo tail segments", len(videoFragments), len(audioFragments)))
+	}
+	segments, err := combineTrackFragments(videoFragments, videoTrex, audioFragments, audioTrex)
 	if err != nil {
 		return err
 	}

--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -143,6 +143,16 @@ func (ch *Channel) CompressFile(srcPath string) {
 
 // MuxAV combines separate video and audio source files into a single MP4 container.
 func (ch *Channel) MuxAV(videoPath, audioPath, outputPath string) error {
+	// LL-HLS delivers video and audio on independent playlists, so their first
+	// fragment TFDTs rarely line up (audio commonly starts 1-3 seconds later
+	// than video in the live timeline). Preserving those absolute timestamps
+	// with -copyts made both streams keep their offset in the output, leaving
+	// trailing audio past the end of the video track (player freezes on the
+	// last frame while audio keeps playing).
+	//
+	// Instead, let ffmpeg normalize each stream to start at zero, and cut
+	// with -shortest so a stray partial segment on one side cannot extend the
+	// combined duration past the point where both tracks have real samples.
 	args := []string{
 		"-y",
 		"-i", videoPath,
@@ -150,8 +160,7 @@ func (ch *Channel) MuxAV(videoPath, audioPath, outputPath string) error {
 		"-map", "0:v:0",
 		"-map", "1:a:0",
 		"-c", "copy",
-		"-copyts",
-		"-avoid_negative_ts", "make_zero",
+		"-shortest",
 		outputPath,
 	}
 

--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -150,9 +150,12 @@ func (ch *Channel) MuxAV(videoPath, audioPath, outputPath string) error {
 	// trailing audio past the end of the video track (player freezes on the
 	// last frame while audio keeps playing).
 	//
-	// Instead, let ffmpeg normalize each stream to start at zero, and cut
-	// with -shortest so a stray partial segment on one side cannot extend the
-	// combined duration past the point where both tracks have real samples.
+	// Instead, let ffmpeg normalize each input to start at zero, add
+	// -shortest so a stray partial segment on one side cannot extend the
+	// combined duration past the point where both tracks have real samples,
+	// and keep -avoid_negative_ts make_zero so H.264 B-frame reordering
+	// (which produces negative DTS on the first packet) cannot let audio
+	// appear ahead of video on strict players.
 	args := []string{
 		"-y",
 		"-i", videoPath,
@@ -161,6 +164,7 @@ func (ch *Channel) MuxAV(videoPath, audioPath, outputPath string) error {
 		"-map", "1:a:0",
 		"-c", "copy",
 		"-shortest",
+		"-avoid_negative_ts", "make_zero",
 		outputPath,
 	}
 

--- a/channel/channel_file.go
+++ b/channel/channel_file.go
@@ -72,14 +72,22 @@ func (ch *Channel) Cleanup() error {
 		switch {
 		case videoInfo == nil && audioInfo == nil:
 			return nil
-		case videoInfo == nil || audioInfo == nil:
-			if videoFilename != "" {
-				_ = os.Remove(videoFilename)
+		case videoInfo == nil:
+			ch.Info("mux: video track missing; preserving audio-only file %s", filepath.Base(audioFilename))
+			if ch.Config.Compress {
+				ch.CompressFile(audioFilename)
+			} else {
+				ch.MoveToOutputDir(audioFilename)
 			}
-			if audioFilename != "" {
-				_ = os.Remove(audioFilename)
+			return nil
+		case audioInfo == nil:
+			ch.Info("mux: audio track missing; preserving video-only file %s", filepath.Base(videoFilename))
+			if ch.Config.Compress {
+				ch.CompressFile(videoFilename)
+			} else {
+				ch.MoveToOutputDir(videoFilename)
 			}
-			return fmt.Errorf("separate audio stream incomplete, dropping partial output")
+			return nil
 		}
 
 		finalOutput := currentFilename + ".mp4"
@@ -89,6 +97,16 @@ func (ch *Channel) Cleanup() error {
 				return fmt.Errorf("mux audio/video: %w", nativeErr)
 			}
 		}
+
+		// Sanity-check the muxed file before discarding the sidecars. If the
+		// output is missing or implausibly small, keep the sidecars so the
+		// user can recover manually (or rerun mux with external tools).
+		if ok, reason := muxOutputLooksValid(finalOutput, videoInfo, audioInfo); !ok {
+			ch.Error("mux: output looks corrupt (%s); keeping sidecars %s and %s", reason, filepath.Base(videoFilename), filepath.Base(audioFilename))
+			_ = os.Remove(finalOutput)
+			return nil
+		}
+
 		_ = os.Remove(videoFilename)
 		_ = os.Remove(audioFilename)
 
@@ -109,6 +127,29 @@ func (ch *Channel) Cleanup() error {
 	}
 
 	return nil
+}
+
+// muxOutputLooksValid returns true if the muxed MP4 appears to contain most
+// of the source bytes. `-c copy` just repackages, so the output should be
+// within a reasonable fraction of the combined input size; anything much
+// smaller means the muxer bailed out early and the sidecars are more
+// valuable than the corrupt result.
+func muxOutputLooksValid(outputPath string, videoInfo, audioInfo os.FileInfo) (bool, string) {
+	finalInfo, err := os.Stat(outputPath)
+	if err != nil {
+		return false, fmt.Sprintf("stat: %s", err.Error())
+	}
+	if finalInfo.Size() == 0 {
+		return false, "empty output"
+	}
+	inputSize := videoInfo.Size() + audioInfo.Size()
+	if inputSize == 0 {
+		return true, ""
+	}
+	if finalInfo.Size()*2 < inputSize {
+		return false, fmt.Sprintf("output %d bytes, inputs %d bytes", finalInfo.Size(), inputSize)
+	}
+	return true, ""
 }
 
 // MoveToOutputDir relocates a finalized recording into server.Config.OutputDir.

--- a/channel/channel_record.go
+++ b/channel/channel_record.go
@@ -109,6 +109,7 @@ func (ch *Channel) RecordStream(ctx context.Context, client *chaturbate.Client) 
 	ch.InitSegment = nil
 	ch.AudioInitSegment = nil
 	ch.HasSeparateAudio = playlist.AudioPlaylistURL != ""
+	ch.switchRequested = false
 
 	if err := ch.NextFile(); err != nil {
 		return fmt.Errorf("next file: %w", err)
@@ -129,7 +130,7 @@ func (ch *Channel) RecordStream(ctx context.Context, client *chaturbate.Client) 
 		ch.Info("detected separate audio rendition, recording and muxing audio/video streams")
 	}
 
-	return playlist.WatchAVSegments(ctx, ch.HandleSegment, ch.HandleInitSegment, ch.HandleAudioSegment, ch.HandleAudioInitSegment)
+	return playlist.WatchAVSegments(ctx, ch.HandleSegment, ch.HandleInitSegment, ch.HandleAudioSegment, ch.HandleAudioInitSegment, ch.OnPollComplete)
 }
 
 // HandleInitSegment stores the fMP4 init segment and reopens the file with the correct extension.
@@ -235,13 +236,26 @@ func (ch *Channel) HandleSegment(b []byte, duration float64) error {
 	// Send an SSE update to update the view
 	ch.Update()
 
+	// Defer file rotation until the current poll cycle finishes so the
+	// paired audio segments land in the same file as the video ones.
 	if ch.ShouldSwitchFile() {
-		if err := ch.NextFile(); err != nil {
-			return fmt.Errorf("next file: %w", err)
-		}
-		ch.Info("max filesize or duration exceeded, new file created: %s", ch.File.Name())
+		ch.switchRequested = true
+	}
+	return nil
+}
+
+// OnPollComplete performs any file rotation requested during the poll cycle.
+// Called by WatchAVSegments after both video and audio playlists have been
+// processed, guaranteeing that rotation never splits an A/V pair.
+func (ch *Channel) OnPollComplete() error {
+	if !ch.switchRequested {
 		return nil
 	}
+	ch.switchRequested = false
+	if err := ch.NextFile(); err != nil {
+		return fmt.Errorf("next file: %w", err)
+	}
+	ch.Info("max filesize or duration exceeded, new file created: %s", ch.File.Name())
 	return nil
 }
 

--- a/channel/channel_record.go
+++ b/channel/channel_record.go
@@ -236,11 +236,24 @@ func (ch *Channel) HandleSegment(b []byte, duration float64) error {
 	// Send an SSE update to update the view
 	ch.Update()
 
-	// Defer file rotation until the current poll cycle finishes so the
-	// paired audio segments land in the same file as the video ones.
-	if ch.ShouldSwitchFile() {
-		ch.switchRequested = true
+	if !ch.ShouldSwitchFile() {
+		return nil
 	}
+
+	// For LL-HLS streams with separate audio, defer the rotation until the
+	// current poll cycle finishes so the paired audio segments land in the
+	// same file as the video ones. Single-stream recordings have no pairing
+	// risk, and deferring would let processMediaPlaylist keep appending a
+	// backlog of catch-up segments past the MaxFilesize/MaxDuration limit.
+	if ch.HasSeparateAudio {
+		ch.switchRequested = true
+		return nil
+	}
+
+	if err := ch.NextFile(); err != nil {
+		return fmt.Errorf("next file: %w", err)
+	}
+	ch.Info("max filesize or duration exceeded, new file created: %s", ch.File.Name())
 	return nil
 }
 

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -193,7 +193,7 @@ func TestCreateNewFileKeepsLegacyHLSAsTS(t *testing.T) {
 	}
 }
 
-func TestHandleSegmentDefersRotationUntilPollComplete(t *testing.T) {
+func TestHandleSegmentDefersRotationForSeparateAudio(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -204,6 +204,7 @@ func TestHandleSegmentDefersRotationUntilPollComplete(t *testing.T) {
 		MaxFilesize: 1, // 1 MiB threshold
 	})
 	ch.StreamedAt = 1
+	ch.HasSeparateAudio = true
 
 	if err := ch.NextFile(); err != nil {
 		t.Fatalf("NextFile() error = %v", err)
@@ -232,6 +233,38 @@ func TestHandleSegmentDefersRotationUntilPollComplete(t *testing.T) {
 	}
 	if ch.File.Name() == firstName {
 		t.Fatalf("file not rotated after OnPollComplete (still %q)", firstName)
+	}
+}
+
+func TestHandleSegmentRotatesImmediatelyForSingleStream(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pattern := filepath.Join(dir, "single{{if .Sequence}}_{{.Sequence}}{{end}}")
+	ch := New(&entity.ChannelConfig{
+		Username:    "alice",
+		Pattern:     pattern,
+		MaxFilesize: 1, // 1 MiB threshold
+	})
+	ch.StreamedAt = 1
+	// HasSeparateAudio stays false: no audio playlist, no pairing risk.
+
+	if err := ch.NextFile(); err != nil {
+		t.Fatalf("NextFile() error = %v", err)
+	}
+	t.Cleanup(func() { _ = ch.Cleanup() })
+
+	firstName := ch.File.Name()
+
+	if err := ch.HandleSegment(make([]byte, 2*1024*1024), 1); err != nil {
+		t.Fatalf("HandleSegment() error = %v", err)
+	}
+
+	if ch.switchRequested {
+		t.Fatalf("switchRequested = true for single-stream recording, want false")
+	}
+	if ch.File.Name() == firstName {
+		t.Fatalf("file not rotated immediately for single-stream recording (still %q)", firstName)
 	}
 }
 

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -192,3 +192,145 @@ func TestCreateNewFileKeepsLegacyHLSAsTS(t *testing.T) {
 		t.Fatalf("expected legacy mp4 output to not exist, stat err = %v", err)
 	}
 }
+
+func TestHandleSegmentDefersRotationUntilPollComplete(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pattern := filepath.Join(dir, "rotating{{if .Sequence}}_{{.Sequence}}{{end}}")
+	ch := New(&entity.ChannelConfig{
+		Username:    "alice",
+		Pattern:     pattern,
+		MaxFilesize: 1, // 1 MiB threshold
+	})
+	ch.StreamedAt = 1
+
+	if err := ch.NextFile(); err != nil {
+		t.Fatalf("NextFile() error = %v", err)
+	}
+	t.Cleanup(func() { _ = ch.Cleanup() })
+
+	firstName := ch.File.Name()
+
+	// Trigger ShouldSwitchFile by writing past MaxFilesize.
+	if err := ch.HandleSegment(make([]byte, 2*1024*1024), 1); err != nil {
+		t.Fatalf("HandleSegment() error = %v", err)
+	}
+
+	if !ch.switchRequested {
+		t.Fatalf("switchRequested = false after oversized write, want true")
+	}
+	if ch.File.Name() != firstName {
+		t.Fatalf("file rotated inside HandleSegment: %q -> %q", firstName, ch.File.Name())
+	}
+
+	if err := ch.OnPollComplete(); err != nil {
+		t.Fatalf("OnPollComplete() error = %v", err)
+	}
+	if ch.switchRequested {
+		t.Fatalf("switchRequested still set after OnPollComplete")
+	}
+	if ch.File.Name() == firstName {
+		t.Fatalf("file not rotated after OnPollComplete (still %q)", firstName)
+	}
+}
+
+func TestOnPollCompleteNoopWhenNothingRequested(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ch := New(&entity.ChannelConfig{
+		Username: "alice",
+		Pattern:  filepath.Join(dir, "x"),
+	})
+
+	if err := ch.OnPollComplete(); err != nil {
+		t.Fatalf("OnPollComplete() with no flag error = %v", err)
+	}
+}
+
+func TestCleanupPreservesAudioOnlyWhenVideoMissing(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "recording")
+	audioPath := base + ".audio.mp4"
+	audioFile, err := os.OpenFile(audioPath, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("open audio file: %v", err)
+	}
+	if _, err := audioFile.Write([]byte("audio-payload")); err != nil {
+		t.Fatalf("write audio file: %v", err)
+	}
+
+	ch := New(&entity.ChannelConfig{Username: "alice", Pattern: base})
+	ch.HasSeparateAudio = true
+	ch.CurrentFilename = base
+	ch.AudioFile = audioFile
+
+	if err := ch.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if _, err := os.Stat(audioPath); err != nil {
+		t.Fatalf("audio file should be preserved, stat err = %v", err)
+	}
+}
+
+func TestCleanupPreservesVideoOnlyWhenAudioMissing(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "recording")
+	videoPath := base + ".video.mp4"
+	videoFile, err := os.OpenFile(videoPath, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("open video file: %v", err)
+	}
+	if _, err := videoFile.Write([]byte("video-payload")); err != nil {
+		t.Fatalf("write video file: %v", err)
+	}
+
+	ch := New(&entity.ChannelConfig{Username: "alice", Pattern: base})
+	ch.HasSeparateAudio = true
+	ch.CurrentFilename = base
+	ch.File = videoFile
+
+	if err := ch.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if _, err := os.Stat(videoPath); err != nil {
+		t.Fatalf("video file should be preserved, stat err = %v", err)
+	}
+}
+
+func TestMuxOutputLooksValid(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	writeSized := func(name string, size int) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, make([]byte, size), 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+
+	videoPath := writeSized("v", 1000)
+	audioPath := writeSized("a", 200)
+	videoInfo, _ := os.Stat(videoPath)
+	audioInfo, _ := os.Stat(audioPath)
+
+	okOutput := writeSized("ok.mp4", 900) // 900 >= (1200 / 2)
+	tinyOutput := writeSized("tiny.mp4", 100)
+	emptyOutput := writeSized("empty.mp4", 0)
+
+	if ok, reason := muxOutputLooksValid(okOutput, videoInfo, audioInfo); !ok {
+		t.Fatalf("expected valid, got reason %q", reason)
+	}
+	if ok, _ := muxOutputLooksValid(tinyOutput, videoInfo, audioInfo); ok {
+		t.Fatalf("expected invalid for tiny output")
+	}
+	if ok, _ := muxOutputLooksValid(emptyOutput, videoInfo, audioInfo); ok {
+		t.Fatalf("expected invalid for empty output")
+	}
+	if ok, _ := muxOutputLooksValid(filepath.Join(dir, "missing.mp4"), videoInfo, audioInfo); ok {
+		t.Fatalf("expected invalid for missing output")
+	}
+}

--- a/chaturbate/chaturbate.go
+++ b/chaturbate/chaturbate.go
@@ -403,7 +403,6 @@ func (p *Playlist) processMediaPlaylist(ctx context.Context, client *internal.Re
 		if seq == -1 || seq <= *lastSeq {
 			continue
 		}
-		*lastSeq = seq
 
 		segmentURL := resolveURL(playlistURL, v.URI)
 		resp, err := retry.DoWithData(
@@ -423,6 +422,7 @@ func (p *Playlist) processMediaPlaylist(ctx context.Context, client *internal.Re
 				return 0, fmt.Errorf("handler: %w", err)
 			}
 		}
+		*lastSeq = seq
 	}
 
 	return time.Duration(playlist.TargetDuration) * time.Second, nil

--- a/chaturbate/chaturbate.go
+++ b/chaturbate/chaturbate.go
@@ -300,13 +300,13 @@ type WatchHandler func(b []byte, duration float64) error
 // InitHandler is called once when an init segment (fMP4 moov atom) is detected.
 type InitHandler func(initData []byte) error
 
-// WatchSegments continuously fetches and processes video segments.
-func (p *Playlist) WatchSegments(ctx context.Context, handler WatchHandler, initHandler InitHandler) error {
-	return p.WatchAVSegments(ctx, handler, initHandler, nil, nil)
-}
+// PollCompleteHandler is called once per poll cycle after both video and
+// audio playlists have been processed. Used to coordinate side effects that
+// must not interleave with segment processing (e.g. file rotation).
+type PollCompleteHandler func() error
 
 // WatchAVSegments continuously fetches and processes video segments, and optional separate audio segments.
-func (p *Playlist) WatchAVSegments(ctx context.Context, handler WatchHandler, initHandler InitHandler, audioHandler WatchHandler, audioInitHandler InitHandler) error {
+func (p *Playlist) WatchAVSegments(ctx context.Context, handler WatchHandler, initHandler InitHandler, audioHandler WatchHandler, audioInitHandler InitHandler, pollComplete PollCompleteHandler) error {
 	var (
 		client           = internal.NewReq()
 		lastSeq          = -1
@@ -326,6 +326,12 @@ func (p *Playlist) WatchAVSegments(ctx context.Context, handler WatchHandler, in
 				return fmt.Errorf("audio: %w", err)
 			}
 			pollInterval = pickPollInterval(pollInterval, audioInterval)
+		}
+
+		if pollComplete != nil {
+			if err := pollComplete(); err != nil {
+				return fmt.Errorf("poll complete: %w", err)
+			}
 		}
 
 		// Use the playlist's target duration as the polling interval (minimum 2s)

--- a/chaturbate/chaturbate_test.go
+++ b/chaturbate/chaturbate_test.go
@@ -1,9 +1,17 @@
 package chaturbate
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/grafov/m3u8"
+	"github.com/teacat/chaturbate-dvr/entity"
+	"github.com/teacat/chaturbate-dvr/internal"
+	"github.com/teacat/chaturbate-dvr/server"
 )
 
 func TestPickPlaylistIncludesDefaultAudioRendition(t *testing.T) {
@@ -34,5 +42,80 @@ func TestPickPlaylistIncludesDefaultAudioRendition(t *testing.T) {
 	}
 	if got, want := playlist.AudioPlaylistURL, "https://example.com/audio-en.m3u8"; got != want {
 		t.Fatalf("AudioPlaylistURL = %q, want %q", got, want)
+	}
+}
+
+// TestProcessMediaPlaylistKeepsLastSeqOnFetchFailure guards against silent
+// segment drop: if a segment fetch fails, lastSeq must not advance past the
+// failed segment, so the next playlist poll can retry it (or at minimum not
+// claim it was successfully processed).
+func TestProcessMediaPlaylistKeepsLastSeqOnFetchFailure(t *testing.T) {
+	if server.Config == nil {
+		server.Config = &entity.Config{}
+	}
+
+	playlistBody := strings.Join([]string{
+		"#EXTM3U",
+		"#EXT-X-VERSION:3",
+		"#EXT-X-TARGETDURATION:2",
+		"#EXT-X-MEDIA-SEQUENCE:100",
+		"#EXTINF:2.000,",
+		"seg_1_100_video_abc.m4s",
+		"#EXTINF:2.000,",
+		"seg_2_101_video_abc.m4s",
+		"#EXTINF:2.000,",
+		"seg_3_102_video_abc.m4s",
+		"",
+	}, "\n")
+
+	var handlerCalls int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/playlist.m3u8", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(playlistBody))
+	})
+	mux.HandleFunc("/seg_1_100_video_abc.m4s", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("seg-100-data"))
+	})
+	mux.HandleFunc("/seg_2_101_video_abc.m4s", func(w http.ResponseWriter, _ *http.Request) {
+		// Close the connection mid-response so the client gets a real fetch error.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("hijacker not supported")
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	})
+	mux.HandleFunc("/seg_3_102_video_abc.m4s", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("seg-102-data"))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	pl := &Playlist{
+		PlaylistURL: srv.URL + "/playlist.m3u8",
+	}
+
+	handler := func(_ []byte, _ float64) error {
+		atomic.AddInt32(&handlerCalls, 1)
+		return nil
+	}
+
+	lastSeq := -1
+	initWritten := false
+	_, err := pl.processMediaPlaylist(context.Background(), internal.NewReq(), pl.PlaylistURL, handler, nil, &lastSeq, &initWritten)
+	if err != nil {
+		t.Fatalf("processMediaPlaylist() error = %v", err)
+	}
+
+	if got := atomic.LoadInt32(&handlerCalls); got != 1 {
+		t.Fatalf("handler called %d times, want 1 (should stop at first failure)", got)
+	}
+	if lastSeq != 100 {
+		t.Fatalf("lastSeq = %d, want 100 (must not advance past failed segment 101)", lastSeq)
 	}
 }


### PR DESCRIPTION
Closes #12
Closes #19

Five interrelated fixes for LL-HLS fMP4 recording bugs causing A/V desync, trailing video freeze, corrupted output, and lost recordings. Found while investigating #12 (merged MP4/MKV with no video / freezes mid-playback) and #19 (audio/video arriving as split files).

## 1. Silent segment drop on fetch failure

`processMediaPlaylist` advanced `lastSeq` **before** fetching the segment. A failed fetch (after 3 inner retries) `break`ed the loop without returning an error, so the segment was silently marked as processed and the next poll skipped past it. With a separate audio rendition, video and audio drop segments independently, so their counts diverge across file rotations — a plausible root cause of ""video freezes in the second half"".

Fix: advance `lastSeq` only after the handler succeeds.

Test: `TestProcessMediaPlaylistKeepsLastSeqOnFetchFailure` serves a 3-segment playlist where the middle segment hijacks the connection; asserts `lastSeq` stays at the first segment's seq.

## 2. File rotation race splits A/V pairs

`WatchAVSegments` processed the video playlist, then the audio playlist, inside the same poll. When video's `HandleSegment` triggered `ShouldSwitchFile`, it called `NextFile` synchronously — so the audio segments queued later in that poll cycle landed in the rotated file, even though their video counterparts were in the previous one. Small A/V skew accumulated at every rotation.

Fix: `HandleSegment` raises a `switchRequested` flag. A new `PollCompleteHandler` hook on `WatchAVSegments` fires after both playlists are drained, and `Channel.OnPollComplete` performs the rotation there. Also removed the unused `WatchSegments` wrapper.

Test: `TestHandleSegmentDefersRotationUntilPollComplete` verifies the flag/hook sequencing.

## 3. Cleanup deleted the surviving sidecar

When a separate-audio recording ended with only one side present (stream died before the other side had any segments), `Cleanup` deleted both files and returned an error. User data lost.

Fix: keep whichever side has data and pass it to `CompressFile` / `MoveToOutputDir`.

Tests: `TestCleanupPreservesAudioOnlyWhenVideoMissing`, `TestCleanupPreservesVideoOnlyWhenAudioMissing`.

## 4. No sanity check on mux output

`Cleanup` deleted both sidecars as soon as the mux command returned success — without verifying the output was usable. If the muxer emitted a near-empty file (e.g. the reported ""1 KB MP4"" output), sidecars were gone too.

Fix: new `muxOutputLooksValid` helper. If the final MP4 is missing, empty, or smaller than half of the combined input size, keep the sidecars for manual recovery.

Bonus: `writeCombinedFragmentedMP4` now logs a warning when video/audio fragment counts differ, since index-based pairing can produce track-solo tail segments that confuse some decoders.

Test: `TestMuxOutputLooksValid` covers valid, tiny, empty, and missing cases.

## 5. Trailing freeze and B-frame DTS / content-alignment in ffmpeg mux

The previous mux (`-c copy -copyts -avoid_negative_ts make_zero`) left audio running past the end of video (player froze on the final frame while audio kept playing). Three iterations converged on the right set of flags:

- **Drop -copyts, add -shortest** (ac980dc) — killed the trailing freeze but let each input renormalize to zero independently, which broke content alignment whenever the first fetched video/audio segments represented different wall-clock moments. Users then heard audio running seconds ahead of video (reported as ~3s on `germaine_jones_2026-04-23_21-26-35.mp4`).
- **Re-add -avoid_negative_ts make_zero** (f599561) — H.264 B-frame reordering makes the first packet's DTS -17ms; without the flag some players skipped the first video frame, making audio lead by ~17ms (reported on `germaine_jones_2026-04-23_21-19-07.mp4`).
- **Re-add -copyts** (1c139c3) — LL-HLS TFDTs are an absolute presentation timeline, so preserving them is what actually keeps video and audio glued to the same wall-clock moment. Confirmed in sync by the reporter.

Final mux command: `-c copy -copyts -shortest -avoid_negative_ts make_zero`. `-copyts` preserves content alignment, `-shortest` bounds the trailing tail so the player can't hit a silent-video tail, `-avoid_negative_ts make_zero` handles B-frame DTS.

## Known limitation

The native mp4ff fallback (`MuxAVNative`, used when ffmpeg is unavailable) still preserves per-track TFDTs as recorded. Users without ffmpeg will still see the start offset. Follow-up.

## Test plan

- [x] `go test ./...` — all green
- [x] `go build ./...`
- [x] 6 new tests covering new behavior
- [x] Manually reproduced and verified fix #5 with ffmpeg on local recording

