### PR TITLE
fix: audio drift during compression and wrong duration in native mux (#24)

### DIFF
--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -86,6 +87,69 @@ func getFpsPassthroughFlag() []string {
 	return fpsPassthroughFlag
 }
 
+// detectStreamStartOffsetSec returns the seconds that should be skipped from
+// the input so the muxed video and audio first samples line up at output time
+// zero. LL-HLS video and audio playlists are independent, so the first
+// fetched fragment from each rarely covers the same wall-clock moment; the
+// later stream's first sample sits at output PTS=delta with the earlier
+// stream filling delta seconds of leading silence/black, which the user
+// reads as "A/V is off". Probing the muxed input lets the compress step skip
+// that leading mismatch while re-encoding (where -ss is sample-accurate).
+//
+// Returns 0 when probing fails, ffprobe is unavailable, or the offset is
+// below alignTrimThreshold (no point trimming sub-frame jitter).
+func detectStreamStartOffsetSec(srcPath string) float64 {
+	probe := func(stream string) (float64, bool) {
+		cmd := exec.Command("ffprobe", "-v", "error",
+			"-select_streams", stream,
+			"-show_entries", "stream=start_time",
+			"-of", "csv=p=0", srcPath)
+		out, err := cmd.Output()
+		if err != nil {
+			return 0, false
+		}
+		v, err := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)
+		if err != nil {
+			return 0, false
+		}
+		return v, true
+	}
+	videoStart, vOK := probe("v:0")
+	audioStart, aOK := probe("a:0")
+	if !vOK || !aOK {
+		return 0
+	}
+	skip := videoStart
+	if audioStart > skip {
+		skip = audioStart
+	}
+	if skip < alignTrimThreshold {
+		return 0
+	}
+	return skip
+}
+
+// alignTrimThreshold is the minimum mismatch (seconds) before we bother
+// trimming. Anything below this is sub-frame jitter that ffmpeg's existing
+// -avoid_negative_ts already handles cleanly.
+const alignTrimThreshold = 0.05
+
+// buildCompressArgs assembles the ffmpeg command line for compress, isolated
+// for testability. skipSec, when above the threshold, becomes an input-side
+// -ss so the leading misaligned segment is dropped accurately by the
+// re-encoder.
+func buildCompressArgs(srcPath, mkvPath string, encoder videoEncoder, fpsFlag []string, skipSec float64) []string {
+	args := []string{"-y", "-copyts", "-start_at_zero"}
+	if skipSec >= alignTrimThreshold {
+		args = append(args, "-ss", strconv.FormatFloat(skipSec, 'f', 3, 64))
+	}
+	args = append(args, "-i", srcPath, "-c:v", encoder.codec)
+	args = append(args, encoder.args...)
+	args = append(args, fpsFlag...)
+	args = append(args, "-c:a", "aac", "-b:a", "128k", "-avoid_negative_ts", "make_zero", mkvPath)
+	return args
+}
+
 // getEncoder returns the cached encoder or detects one
 func getEncoder() videoEncoder {
 	detectedEncoderOnce.Do(func() {
@@ -123,15 +187,21 @@ func (ch *Channel) CompressFile(srcPath string) {
 		// Get the best available encoder
 		encoder := getEncoder()
 
+		// Detect any leading misalignment between the muxed video/audio so
+		// the re-encoder can drop the leading silent gap. Probing happens
+		// before the size log so the message reflects whatever portion will
+		// actually end up in the output.
+		skipSec := detectStreamStartOffsetSec(srcPath)
+		if skipSec >= alignTrimThreshold {
+			ch.Info("compress: trimming %.3fs of leading misalignment from %s", skipSec, srcFilename)
+		}
+
 		ch.Info("compress: encoding %s (%s) using %s", srcFilename, internal.FormatFilesize(int(srcSize)), encoder.name)
 
 		// Preserve the recorded timeline while re-encoding. LL-HLS/fMP4
 		// inputs often carry variable frame timing; letting ffmpeg
 		// normalize frame cadence can make audio drift during compression.
-		args := []string{"-y", "-copyts", "-start_at_zero", "-i", srcPath, "-c:v", encoder.codec}
-		args = append(args, encoder.args...)
-		args = append(args, getFpsPassthroughFlag()...)
-		args = append(args, "-c:a", "aac", "-b:a", "128k", "-avoid_negative_ts", "make_zero", mkvPath)
+		args := buildCompressArgs(srcPath, mkvPath, encoder, getFpsPassthroughFlag(), skipSec)
 
 		cmd := exec.Command("ffmpeg", args...)
 		output, err := cmd.CombinedOutput()

--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -98,10 +98,12 @@ func (ch *Channel) CompressFile(srcPath string) {
 
 		ch.Info("compress: encoding %s (%s) using %s", srcFilename, internal.FormatFilesize(int(srcSize)), encoder.name)
 
-		// Build ffmpeg command
-		args := []string{"-y", "-i", srcPath, "-c:v", encoder.codec}
+		// Preserve the recorded timeline while re-encoding. LL-HLS/fMP4
+		// inputs often carry variable frame timing; letting ffmpeg
+		// normalize frame cadence can make audio drift during compression.
+		args := []string{"-y", "-copyts", "-start_at_zero", "-i", srcPath, "-c:v", encoder.codec}
 		args = append(args, encoder.args...)
-		args = append(args, "-c:a", "aac", "-b:a", "128k", mkvPath)
+		args = append(args, "-fps_mode", "passthrough", "-c:a", "aac", "-b:a", "128k", "-avoid_negative_ts", "make_zero", mkvPath)
 
 		cmd := exec.Command("ffmpeg", args...)
 		output, err := cmd.CombinedOutput()
@@ -239,13 +241,30 @@ func writeCombinedFragmentedMP4(w io.Writer, videoFile, audioFile *mp4.File, war
 		return err
 	}
 
+	// Compute total media-timescale duration from the source fragments
+	// while track IDs still match the original trex values, so the duration
+	// hints written into mvhd/tkhd/mdhd reflect the real recorded length.
+	// Without this, mvhd.Duration stays 0 (the value from a live init
+	// segment), and players that read it as a hint instead of scanning every
+	// fragment report the recording as much shorter than it is.
+	videoMediaDur := sumFragmentDurations(videoFragments, videoTrex)
+	audioMediaDur := sumFragmentDurations(audioFragments, audioTrex)
+
 	ftyp := videoFile.Init.Ftyp
 	moov := videoFile.Init.Moov
 	if len(moov.Traks) != 1 || moov.Mvex == nil || len(moov.Mvex.Trexs) != 1 {
 		return fmt.Errorf("expected single-track video init")
 	}
 
-	moov.Traks[0].Tkhd.TrackID = videoTrackID
+	videoTrak := moov.Traks[0]
+	if videoTrak.Mdia == nil || videoTrak.Mdia.Mdhd == nil {
+		return fmt.Errorf("video track missing mdhd")
+	}
+	if audioTrack.Mdia == nil || audioTrack.Mdia.Mdhd == nil {
+		return fmt.Errorf("audio track missing mdhd")
+	}
+
+	videoTrak.Tkhd.TrackID = videoTrackID
 	moov.Mvex.Trexs[0].TrackID = videoTrackID
 
 	audioTrack.Tkhd.TrackID = audioTrackID
@@ -255,6 +274,26 @@ func writeCombinedFragmentedMP4(w io.Writer, videoFile, audioFile *mp4.File, war
 	moov.Mvex.AddChild(audioTrex)
 	moov.Mvhd.NextTrackID = audioTrackID + 1
 
+	movieTimescale := uint64(moov.Mvhd.Timescale)
+	if movieTimescale == 0 {
+		movieTimescale = 1
+	}
+	videoMdhdTimescale := uint64(videoTrak.Mdia.Mdhd.Timescale)
+	audioMdhdTimescale := uint64(audioTrack.Mdia.Mdhd.Timescale)
+
+	videoTrak.Mdia.Mdhd.Duration = videoMediaDur
+	audioTrack.Mdia.Mdhd.Duration = audioMediaDur
+
+	videoMovieDur := scaleDuration(videoMediaDur, movieTimescale, videoMdhdTimescale)
+	audioMovieDur := scaleDuration(audioMediaDur, movieTimescale, audioMdhdTimescale)
+	videoTrak.Tkhd.Duration = videoMovieDur
+	audioTrack.Tkhd.Duration = audioMovieDur
+
+	moov.Mvhd.Duration = videoMovieDur
+	if audioMovieDur > moov.Mvhd.Duration {
+		moov.Mvhd.Duration = audioMovieDur
+	}
+
 	out := mp4.NewFile()
 	out.AddChild(ftyp, 0)
 	out.AddChild(moov, ftyp.Size())
@@ -263,6 +302,46 @@ func writeCombinedFragmentedMP4(w io.Writer, videoFile, audioFile *mp4.File, war
 	}
 
 	return out.Encode(w)
+}
+
+// sumFragmentDurations totals the trun durations of every fragment that
+// belongs to the trex's track, falling back to the per-fragment or trex
+// default sample duration when individual sample durations are absent.
+func sumFragmentDurations(fragments []*mp4.Fragment, trex *mp4.TrexBox) uint64 {
+	if trex == nil {
+		return 0
+	}
+	var total uint64
+	for _, frag := range fragments {
+		if frag == nil || frag.Moof == nil {
+			continue
+		}
+		for _, traf := range frag.Moof.Trafs {
+			if traf == nil || traf.Tfhd == nil || traf.Tfhd.TrackID != trex.TrackID {
+				continue
+			}
+			defaultDur := trex.DefaultSampleDuration
+			if traf.Tfhd.HasDefaultSampleDuration() {
+				defaultDur = traf.Tfhd.DefaultSampleDuration
+			}
+			for _, trun := range traf.Truns {
+				if trun == nil {
+					continue
+				}
+				total += trun.Duration(defaultDur)
+			}
+		}
+	}
+	return total
+}
+
+// scaleDuration converts duration from one timescale to another using
+// integer math, guarding against zero divisors.
+func scaleDuration(dur, dstTimescale, srcTimescale uint64) uint64 {
+	if srcTimescale == 0 {
+		return 0
+	}
+	return dur * dstTimescale / srcTimescale
 }
 
 func sourceTrack(file *mp4.File, handlerType string) (*mp4.TrakBox, *mp4.TrexBox, error) {
@@ -355,4 +434,3 @@ func collectFragments(file *mp4.File) []*mp4.Fragment {
 	}
 	return fragments
 }
-

--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -25,6 +25,14 @@ var (
 	detectedEncoderOnce sync.Once
 )
 
+// Frame-timing flag detection cache. ffmpeg 5+ uses -fps_mode (per-stream);
+// 4.x only knows the legacy global -vsync. Probing once at runtime keeps
+// CompressFile working on either generation without a static dependency.
+var (
+	fpsPassthroughFlag []string
+	fpsPassthroughOnce sync.Once
+)
+
 // videoEncoder represents a video encoder configuration
 type videoEncoder struct {
 	name  string   // display name
@@ -57,6 +65,25 @@ func detectEncoder() (videoEncoder, string) {
 	}
 	// Should not reach here since libx264 is always available if ffmpeg is installed
 	return availableEncoders[len(availableEncoders)-1], "CPU"
+}
+
+// getFpsPassthroughFlag returns the ffmpeg flag(s) that pass each video
+// frame's timestamp straight through to the muxer. Modern ffmpeg uses
+// -fps_mode passthrough; older 4.x exits with "Unrecognized option
+// 'fps_mode'", so we probe support once and fall back to -vsync passthrough
+// (deprecated on 5+, but still functional through ffmpeg 8).
+func getFpsPassthroughFlag() []string {
+	fpsPassthroughOnce.Do(func() {
+		cmd := exec.Command("ffmpeg", "-hide_banner", "-loglevel", "error",
+			"-f", "lavfi", "-i", "nullsrc=s=64x64:d=0.05",
+			"-fps_mode", "passthrough", "-f", "null", "-")
+		if err := cmd.Run(); err == nil {
+			fpsPassthroughFlag = []string{"-fps_mode", "passthrough"}
+		} else {
+			fpsPassthroughFlag = []string{"-vsync", "passthrough"}
+		}
+	})
+	return fpsPassthroughFlag
 }
 
 // getEncoder returns the cached encoder or detects one
@@ -103,7 +130,8 @@ func (ch *Channel) CompressFile(srcPath string) {
 		// normalize frame cadence can make audio drift during compression.
 		args := []string{"-y", "-copyts", "-start_at_zero", "-i", srcPath, "-c:v", encoder.codec}
 		args = append(args, encoder.args...)
-		args = append(args, "-fps_mode", "passthrough", "-c:a", "aac", "-b:a", "128k", "-avoid_negative_ts", "make_zero", mkvPath)
+		args = append(args, getFpsPassthroughFlag()...)
+		args = append(args, "-c:a", "aac", "-b:a", "128k", "-avoid_negative_ts", "make_zero", mkvPath)
 
 		cmd := exec.Command("ffmpeg", args...)
 		output, err := cmd.CombinedOutput()

--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -119,14 +119,22 @@ func detectStreamStartOffsetSec(srcPath string) float64 {
 	if !vOK || !aOK {
 		return 0
 	}
-	skip := videoStart
-	if audioStart > skip {
-		skip = audioStart
+	// Trim is only justified when the two streams disagree about where they
+	// start. If both share the same baseline (e.g. both at 1.5s on inputs
+	// produced by other tools), -ss would chop real aligned content even
+	// though there is nothing to fix. Compare the offset between streams,
+	// not the absolute baseline.
+	diff := videoStart - audioStart
+	if diff < 0 {
+		diff = -diff
 	}
-	if skip < alignTrimThreshold {
+	if diff < alignTrimThreshold {
 		return 0
 	}
-	return skip
+	if videoStart > audioStart {
+		return videoStart
+	}
+	return audioStart
 }
 
 // alignTrimThreshold is the minimum mismatch (seconds) before we bother
@@ -380,17 +388,22 @@ func writeCombinedFragmentedMP4(w io.Writer, videoFile, audioFile *mp4.File, war
 	audioMdhdTimescale := uint64(audioTrack.Mdia.Mdhd.Timescale)
 
 	videoTrak.Mdia.Mdhd.Duration = videoMediaDur
+	promoteVersionForLongDuration(&videoTrak.Mdia.Mdhd.Version, videoMediaDur)
 	audioTrack.Mdia.Mdhd.Duration = audioMediaDur
+	promoteVersionForLongDuration(&audioTrack.Mdia.Mdhd.Version, audioMediaDur)
 
 	videoMovieDur := scaleDuration(videoMediaDur, movieTimescale, videoMdhdTimescale)
 	audioMovieDur := scaleDuration(audioMediaDur, movieTimescale, audioMdhdTimescale)
 	videoTrak.Tkhd.Duration = videoMovieDur
+	promoteVersionForLongDuration(&videoTrak.Tkhd.Version, videoMovieDur)
 	audioTrack.Tkhd.Duration = audioMovieDur
+	promoteVersionForLongDuration(&audioTrack.Tkhd.Version, audioMovieDur)
 
 	moov.Mvhd.Duration = videoMovieDur
 	if audioMovieDur > moov.Mvhd.Duration {
 		moov.Mvhd.Duration = audioMovieDur
 	}
+	promoteVersionForLongDuration(&moov.Mvhd.Version, moov.Mvhd.Duration)
 
 	out := mp4.NewFile()
 	out.AddChild(ftyp, 0)
@@ -440,6 +453,25 @@ func scaleDuration(dur, dstTimescale, srcTimescale uint64) uint64 {
 		return 0
 	}
 	return dur * dstTimescale / srcTimescale
+}
+
+// maxV0Duration is the largest value mp4ff can serialize into a version-0
+// mvhd/tkhd/mdhd Duration field; the wire format uses uint32 there. At a
+// 90 kHz video timescale this caps version-0 boxes at ~13.25 hours.
+const maxV0Duration uint64 = 0xFFFFFFFF
+
+// promoteVersionForLongDuration upgrades a header box from version 0 to
+// version 1 when the duration to be encoded exceeds the 32-bit field used
+// in the version-0 wire format. Without this, recordings longer than the
+// version-0 limit would be silently truncated by mp4ff's encoder even
+// though we set the uint64 Duration field to the correct value.
+func promoteVersionForLongDuration(version *byte, duration uint64) {
+	if version == nil {
+		return
+	}
+	if duration > maxV0Duration && *version == 0 {
+		*version = 1
+	}
 }
 
 func sourceTrack(file *mp4.File, handlerType string) (*mp4.TrakBox, *mp4.TrexBox, error) {

--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -139,10 +139,7 @@ func detectStreamStartOffsetSec(srcPath string) float64 {
 	if diff < alignTrimThreshold {
 		return 0
 	}
-	if videoStart > audioStart {
-		return videoStart
-	}
-	return audioStart
+	return diff
 }
 
 // alignTrimThreshold is the minimum mismatch (seconds) before we bother

--- a/channel/channel_compress.go
+++ b/channel/channel_compress.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Eyevinn/mp4ff/mp4"
 	"github.com/teacat/chaturbate-dvr/internal"
@@ -19,6 +21,8 @@ const (
 	videoTrackID uint32 = 1
 	audioTrackID uint32 = 2
 )
+
+const ffmpegProbeTimeout = 5 * time.Second
 
 // GPU encoder detection cache
 var (
@@ -75,7 +79,9 @@ func detectEncoder() (videoEncoder, string) {
 // (deprecated on 5+, but still functional through ffmpeg 8).
 func getFpsPassthroughFlag() []string {
 	fpsPassthroughOnce.Do(func() {
-		cmd := exec.Command("ffmpeg", "-hide_banner", "-loglevel", "error",
+		ctx, cancel := context.WithTimeout(context.Background(), ffmpegProbeTimeout)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "ffmpeg", "-hide_banner", "-loglevel", "error",
 			"-f", "lavfi", "-i", "nullsrc=s=64x64:d=0.05",
 			"-fps_mode", "passthrough", "-f", "null", "-")
 		if err := cmd.Run(); err == nil {
@@ -100,7 +106,9 @@ func getFpsPassthroughFlag() []string {
 // below alignTrimThreshold (no point trimming sub-frame jitter).
 func detectStreamStartOffsetSec(srcPath string) float64 {
 	probe := func(stream string) (float64, bool) {
-		cmd := exec.Command("ffprobe", "-v", "error",
+		ctx, cancel := context.WithTimeout(context.Background(), ffmpegProbeTimeout)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "ffprobe", "-v", "error",
 			"-select_streams", stream,
 			"-show_entries", "stream=start_time",
 			"-of", "csv=p=0", srcPath)

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -399,6 +399,12 @@ esac
 	if err := os.WriteFile(ffmpegPath, []byte(script), 0755); err != nil {
 		t.Fatalf("write fake ffmpeg: %v", err)
 	}
+	// Stub ffprobe to report aligned streams so this test only checks the
+	// timing-preservation flags. Offset trimming is exercised separately.
+	ffprobePath := filepath.Join(dir, "ffprobe")
+	if err := os.WriteFile(ffprobePath, []byte("#!/bin/sh\necho 0.000000\n"), 0755); err != nil {
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
 	t.Setenv("PATH", dir)
 
 	detectedEncoder = ""
@@ -444,6 +450,87 @@ esac
 		!strings.Contains(compressArgs, "-vsync passthrough") {
 		t.Fatalf("compress args = %q, want -fps_mode or -vsync passthrough", compressArgs)
 	}
+	// Aligned streams (ffprobe stub returns 0) must not insert -ss.
+	if strings.Contains(compressArgs, "-ss ") {
+		t.Fatalf("compress args = %q, did not expect -ss when streams are aligned", compressArgs)
+	}
+}
+
+func TestBuildCompressArgsAddsLeadingTrim(t *testing.T) {
+	t.Parallel()
+
+	enc := videoEncoder{name: "CPU", codec: "libx264", args: []string{"-preset", "medium", "-crf", "23"}}
+	fps := []string{"-fps_mode", "passthrough"}
+
+	aligned := buildCompressArgs("/in.mp4", "/out.mkv", enc, fps, 0)
+	if containsArg(aligned, "-ss") {
+		t.Fatalf("aligned compress args contain -ss: %v", aligned)
+	}
+
+	misaligned := buildCompressArgs("/in.mp4", "/out.mkv", enc, fps, 1.246)
+	idx := indexOfArg(misaligned, "-ss")
+	if idx < 0 {
+		t.Fatalf("misaligned compress args missing -ss: %v", misaligned)
+	}
+	if got := misaligned[idx+1]; got != "1.246" {
+		t.Fatalf("-ss value = %q, want 1.246", got)
+	}
+	// -ss must precede -i so it applies as input-side seek.
+	if iIdx := indexOfArg(misaligned, "-i"); iIdx <= idx {
+		t.Fatalf("-ss (%d) must come before -i (%d): %v", idx, iIdx, misaligned)
+	}
+
+	// Sub-threshold offsets are ignored to avoid trimming sub-frame jitter.
+	jitter := buildCompressArgs("/in.mp4", "/out.mkv", enc, fps, 0.02)
+	if containsArg(jitter, "-ss") {
+		t.Fatalf("sub-threshold offset triggered -ss: %v", jitter)
+	}
+}
+
+func TestDetectStreamStartOffsetSecWithFakeFFprobe(t *testing.T) {
+	dir := t.TempDir()
+	ffprobe := filepath.Join(dir, "ffprobe")
+	// Fake ffprobe replies with the value matching the requested stream.
+	script := `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    "v:0") want=v ;;
+    "a:0") want=a ;;
+  esac
+done
+case "$want" in
+  v) echo 0.000000 ;;
+  a) echo 1.246000 ;;
+esac
+`
+	if err := os.WriteFile(ffprobe, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake ffprobe: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	got := detectStreamStartOffsetSec(filepath.Join(dir, "irrelevant.mp4"))
+	if got < 1.245 || got > 1.247 {
+		t.Fatalf("detected offset = %v, want ~1.246", got)
+	}
+
+	// Probe failure (ffprobe missing) returns 0 without panicking.
+	t.Setenv("PATH", t.TempDir())
+	if got := detectStreamStartOffsetSec("/nope.mp4"); got != 0 {
+		t.Fatalf("expected 0 when ffprobe missing, got %v", got)
+	}
+}
+
+func containsArg(args []string, target string) bool {
+	return indexOfArg(args, target) >= 0
+}
+
+func indexOfArg(args []string, target string) int {
+	for i, a := range args {
+		if a == target {
+			return i
+		}
+	}
+	return -1
 }
 
 func TestNativeMuxWritesNonZeroDuration(t *testing.T) {

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -2,10 +2,14 @@ package channel
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/Eyevinn/mp4ff/mp4"
 	"github.com/teacat/chaturbate-dvr/entity"
@@ -89,6 +93,14 @@ func TestCreateNewFileWritesInitSegmentForRotatedFMP4Files(t *testing.T) {
 // buildFragmentedMP4 creates a minimal valid fragmented MP4 in memory with one track and one sample.
 func buildFragmentedMP4(t *testing.T, mediaType string, timescale uint32, sampleData []byte) []byte {
 	t.Helper()
+	return buildFragmentedMP4WithSamples(t, mediaType, timescale, []byte(sampleData), 1)
+}
+
+// buildFragmentedMP4WithSamples creates a fragmented MP4 with the requested
+// number of single-sample fragments, each holding sampleData and lasting one
+// second of media (Dur = timescale per sample).
+func buildFragmentedMP4WithSamples(t *testing.T, mediaType string, timescale uint32, sampleData []byte, fragments int) []byte {
+	t.Helper()
 
 	init := mp4.CreateEmptyInit()
 	init.AddEmptyTrack(timescale, mediaType, "und")
@@ -96,26 +108,28 @@ func buildFragmentedMP4(t *testing.T, mediaType string, timescale uint32, sample
 		t.Fatalf("TweakSingleTrakLive(%s) error = %v", mediaType, err)
 	}
 
-	seg := mp4.NewMediaSegmentWithoutStyp()
-	frag, err := mp4.CreateFragment(1, 1)
-	if err != nil {
-		t.Fatalf("CreateFragment(%s) error = %v", mediaType, err)
-	}
-	if err := frag.AddFullSampleToTrack(mp4.FullSample{
-		Sample:     mp4.Sample{Flags: mp4.SyncSampleFlags, Dur: timescale, Size: uint32(len(sampleData))},
-		DecodeTime: 0,
-		Data:       sampleData,
-	}, 1); err != nil {
-		t.Fatalf("AddFullSampleToTrack(%s) error = %v", mediaType, err)
-	}
-	seg.AddFragment(frag)
-
 	var buf bytes.Buffer
 	if err := init.Encode(&buf); err != nil {
 		t.Fatalf("encode init(%s) error = %v", mediaType, err)
 	}
-	if err := seg.Encode(&buf); err != nil {
-		t.Fatalf("encode segment(%s) error = %v", mediaType, err)
+
+	for i := 0; i < fragments; i++ {
+		seg := mp4.NewMediaSegmentWithoutStyp()
+		frag, err := mp4.CreateFragment(uint32(i+1), 1)
+		if err != nil {
+			t.Fatalf("CreateFragment(%s) error = %v", mediaType, err)
+		}
+		if err := frag.AddFullSampleToTrack(mp4.FullSample{
+			Sample:     mp4.Sample{Flags: mp4.SyncSampleFlags, Dur: timescale, Size: uint32(len(sampleData))},
+			DecodeTime: uint64(i) * uint64(timescale),
+			Data:       sampleData,
+		}, 1); err != nil {
+			t.Fatalf("AddFullSampleToTrack(%s) error = %v", mediaType, err)
+		}
+		seg.AddFragment(frag)
+		if err := seg.Encode(&buf); err != nil {
+			t.Fatalf("encode segment(%s) error = %v", mediaType, err)
+		}
 	}
 	return buf.Bytes()
 }
@@ -125,7 +139,7 @@ func TestCleanupNativeMuxesSeparateTracksWhenFFmpegUnavailable(t *testing.T) {
 	t.Setenv("PATH", dir)
 
 	videoMP4 := buildFragmentedMP4(t, "video", 90000, []byte{0x00, 0x00, 0x00, 0x01, 0x67}) // fake NAL unit
-	audioMP4 := buildFragmentedMP4(t, "audio", 44100, []byte{0xFF, 0xF1})                    // fake AAC frame
+	audioMP4 := buildFragmentedMP4(t, "audio", 44100, []byte{0xFF, 0xF1})                   // fake AAC frame
 
 	base := filepath.Join(dir, "recording")
 	ch := New(&entity.ChannelConfig{
@@ -365,5 +379,116 @@ func TestMuxOutputLooksValid(t *testing.T) {
 	}
 	if ok, _ := muxOutputLooksValid(filepath.Join(dir, "missing.mp4"), videoInfo, audioInfo); ok {
 		t.Fatalf("expected invalid for missing output")
+	}
+}
+
+func TestCompressFilePreservesInputTiming(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "ffmpeg.log")
+	ffmpegPath := filepath.Join(dir, "ffmpeg")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+last=""
+for arg in "$@"; do
+  last="$arg"
+done
+case "$last" in
+  *.mkv) printf 'compressed' > "$last" ;;
+esac
+`, logPath)
+	if err := os.WriteFile(ffmpegPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	detectedEncoder = ""
+	detectedEncoderOnce = sync.Once{}
+
+	srcPath := filepath.Join(dir, "recording.mp4")
+	if err := os.WriteFile(srcPath, []byte("source-video"), 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	ch := New(&entity.ChannelConfig{Username: "alice", Pattern: filepath.Join(dir, "recording")})
+	ch.CompressFile(srcPath)
+
+	var log string
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(logPath)
+		if err == nil {
+			log = string(data)
+			if strings.Contains(log, ".mkv") {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !strings.Contains(log, ".mkv") {
+		t.Fatalf("compress ffmpeg command did not run, log = %q", log)
+	}
+
+	lines := strings.Split(strings.TrimSpace(log), "\n")
+	compressArgs := lines[len(lines)-1]
+	for _, want := range []string{"-copyts", "-start_at_zero", "-fps_mode passthrough"} {
+		if !strings.Contains(compressArgs, want) {
+			t.Fatalf("compress args = %q, want %q to preserve input timing", compressArgs, want)
+		}
+	}
+}
+
+func TestNativeMuxWritesNonZeroDuration(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+
+	const fragments = 5
+	videoMP4 := buildFragmentedMP4WithSamples(t, "video", 90000, []byte{0x00, 0x00, 0x00, 0x01, 0x67}, fragments)
+	audioMP4 := buildFragmentedMP4WithSamples(t, "audio", 44100, []byte{0xFF, 0xF1}, fragments)
+
+	base := filepath.Join(dir, "recording")
+	ch := New(&entity.ChannelConfig{
+		Username: "alice",
+		Pattern:  base,
+	})
+	ch.HasSeparateAudio = true
+	ch.CurrentFilename = base
+	ch.InitSegment = videoMP4
+	ch.AudioInitSegment = audioMP4
+
+	if err := ch.CreateNewFile(base); err != nil {
+		t.Fatalf("CreateNewFile() error = %v", err)
+	}
+	if err := ch.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	muxed, err := mp4.ReadMP4File(base + ".mp4")
+	if err != nil {
+		t.Fatalf("ReadMP4File() error = %v", err)
+	}
+	mvhd := muxed.Init.Moov.Mvhd
+	if mvhd.Duration == 0 {
+		t.Fatalf("expected mvhd.Duration > 0 to advertise recorded length, got 0 (timescale=%d)", mvhd.Timescale)
+	}
+	gotSeconds := float64(mvhd.Duration) / float64(mvhd.Timescale)
+	if gotSeconds < float64(fragments)-0.5 || gotSeconds > float64(fragments)+0.5 {
+		t.Fatalf("mvhd reports %.2fs, want ~%ds", gotSeconds, fragments)
+	}
+
+	for _, trak := range muxed.Init.Moov.Traks {
+		if trak.Tkhd.Duration == 0 {
+			t.Fatalf("track %d tkhd.Duration is zero", trak.Tkhd.TrackID)
+		}
+		if trak.Mdia == nil || trak.Mdia.Mdhd == nil {
+			t.Fatalf("track %d missing mdhd", trak.Tkhd.TrackID)
+		}
+		mdhd := trak.Mdia.Mdhd
+		if mdhd.Duration == 0 {
+			t.Fatalf("track %d mdhd.Duration is zero", trak.Tkhd.TrackID)
+		}
+		mediaSeconds := float64(mdhd.Duration) / float64(mdhd.Timescale)
+		if mediaSeconds < float64(fragments)-0.5 || mediaSeconds > float64(fragments)+0.5 {
+			t.Fatalf("track %d mdhd reports %.2fs, want ~%ds", trak.Tkhd.TrackID, mediaSeconds, fragments)
+		}
 	}
 }

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -403,6 +403,8 @@ esac
 
 	detectedEncoder = ""
 	detectedEncoderOnce = sync.Once{}
+	fpsPassthroughFlag = nil
+	fpsPassthroughOnce = sync.Once{}
 
 	srcPath := filepath.Join(dir, "recording.mp4")
 	if err := os.WriteFile(srcPath, []byte("source-video"), 0644); err != nil {
@@ -430,10 +432,17 @@ esac
 
 	lines := strings.Split(strings.TrimSpace(log), "\n")
 	compressArgs := lines[len(lines)-1]
-	for _, want := range []string{"-copyts", "-start_at_zero", "-fps_mode passthrough"} {
+	for _, want := range []string{"-copyts", "-start_at_zero"} {
 		if !strings.Contains(compressArgs, want) {
 			t.Fatalf("compress args = %q, want %q to preserve input timing", compressArgs, want)
 		}
+	}
+	// Accept either modern (-fps_mode passthrough) or legacy (-vsync
+	// passthrough) frame-timing flag, since the chosen one depends on the
+	// installed ffmpeg version.
+	if !strings.Contains(compressArgs, "-fps_mode passthrough") &&
+		!strings.Contains(compressArgs, "-vsync passthrough") {
+		t.Fatalf("compress args = %q, want -fps_mode or -vsync passthrough", compressArgs)
 	}
 }
 

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -408,14 +408,12 @@ esac
 	t.Setenv("PATH", dir)
 
 	oldDetectedEncoder := detectedEncoder
-	oldDetectedEncoderOnce := detectedEncoderOnce
 	oldFpsPassthroughFlag := append([]string(nil), fpsPassthroughFlag...)
-	oldFpsPassthroughOnce := fpsPassthroughOnce
 	t.Cleanup(func() {
 		detectedEncoder = oldDetectedEncoder
-		detectedEncoderOnce = oldDetectedEncoderOnce
 		fpsPassthroughFlag = oldFpsPassthroughFlag
-		fpsPassthroughOnce = oldFpsPassthroughOnce
+		detectedEncoderOnce = sync.Once{}
+		fpsPassthroughOnce = sync.Once{}
 	})
 
 	detectedEncoder = ""
@@ -528,6 +526,7 @@ exit 1
 		{name: "audio leads", v: "1.246000", a: "0.000000", want: 1.246, wantTrim: true, tolerance: 0.001},
 		{name: "aligned at zero", v: "0.000000", a: "0.000000", want: 0, wantTrim: false},
 		{name: "aligned at non-zero baseline", v: "1.500000", a: "1.500000", want: 0, wantTrim: false},
+		{name: "offset from non-zero baseline", v: "120.000000", a: "121.000000", want: 1.000, wantTrim: true, tolerance: 0.001},
 		{name: "near-zero jitter ignored", v: "0.000000", a: "0.020000", want: 0, wantTrim: false},
 	}
 	for _, tc := range cases {

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -490,33 +490,109 @@ func TestBuildCompressArgsAddsLeadingTrim(t *testing.T) {
 func TestDetectStreamStartOffsetSecWithFakeFFprobe(t *testing.T) {
 	dir := t.TempDir()
 	ffprobe := filepath.Join(dir, "ffprobe")
-	// Fake ffprobe replies with the value matching the requested stream.
+	// Fake ffprobe reads the desired video/audio start times from env vars
+	// so individual sub-cases can drive different scenarios.
 	script := `#!/bin/sh
 for arg in "$@"; do
   case "$arg" in
-    "v:0") want=v ;;
-    "a:0") want=a ;;
+    "v:0") echo "$FAKE_V_START" ; exit 0 ;;
+    "a:0") echo "$FAKE_A_START" ; exit 0 ;;
   esac
 done
-case "$want" in
-  v) echo 0.000000 ;;
-  a) echo 1.246000 ;;
-esac
+exit 1
 `
 	if err := os.WriteFile(ffprobe, []byte(script), 0755); err != nil {
 		t.Fatalf("write fake ffprobe: %v", err)
 	}
 	t.Setenv("PATH", dir)
 
-	got := detectStreamStartOffsetSec(filepath.Join(dir, "irrelevant.mp4"))
-	if got < 1.245 || got > 1.247 {
-		t.Fatalf("detected offset = %v, want ~1.246", got)
+	cases := []struct {
+		name      string
+		v, a      string
+		want      float64
+		wantTrim  bool
+		tolerance float64
+	}{
+		{name: "video leads", v: "0.000000", a: "1.246000", want: 1.246, wantTrim: true, tolerance: 0.001},
+		{name: "audio leads", v: "1.246000", a: "0.000000", want: 1.246, wantTrim: true, tolerance: 0.001},
+		{name: "aligned at zero", v: "0.000000", a: "0.000000", want: 0, wantTrim: false},
+		{name: "aligned at non-zero baseline", v: "1.500000", a: "1.500000", want: 0, wantTrim: false},
+		{name: "near-zero jitter ignored", v: "0.000000", a: "0.020000", want: 0, wantTrim: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("FAKE_V_START", tc.v)
+			t.Setenv("FAKE_A_START", tc.a)
+			got := detectStreamStartOffsetSec(filepath.Join(dir, "irrelevant.mp4"))
+			if !tc.wantTrim {
+				if got != 0 {
+					t.Fatalf("got skip = %v, want 0 (no trim)", got)
+				}
+				return
+			}
+			if got < tc.want-tc.tolerance || got > tc.want+tc.tolerance {
+				t.Fatalf("got skip = %v, want %v ±%v", got, tc.want, tc.tolerance)
+			}
+		})
 	}
 
 	// Probe failure (ffprobe missing) returns 0 without panicking.
 	t.Setenv("PATH", t.TempDir())
 	if got := detectStreamStartOffsetSec("/nope.mp4"); got != 0 {
 		t.Fatalf("expected 0 when ffprobe missing, got %v", got)
+	}
+}
+
+func TestNativeMuxPromotesVersionForLongDurations(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+
+	// Fragment Dur = timescale = 1e9 ticks (1 second wallclock per fragment).
+	// Five fragments yields 5e9 mdhd ticks per track, which exceeds the
+	// version-0 32-bit Duration limit (~4.29e9). Without version promotion
+	// mp4ff would truncate the encoded duration silently.
+	const hugeTimescale uint32 = 1_000_000_000
+	videoMP4 := buildFragmentedMP4WithSamples(t, "video", hugeTimescale, []byte{0x00, 0x00, 0x00, 0x01, 0x67}, 5)
+	audioMP4 := buildFragmentedMP4WithSamples(t, "audio", hugeTimescale, []byte{0xFF, 0xF1}, 5)
+
+	base := filepath.Join(dir, "long")
+	ch := New(&entity.ChannelConfig{Username: "alice", Pattern: base})
+	ch.HasSeparateAudio = true
+	ch.CurrentFilename = base
+	ch.InitSegment = videoMP4
+	ch.AudioInitSegment = audioMP4
+
+	if err := ch.CreateNewFile(base); err != nil {
+		t.Fatalf("CreateNewFile() error = %v", err)
+	}
+	if err := ch.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	muxed, err := mp4.ReadMP4File(base + ".mp4")
+	if err != nil {
+		t.Fatalf("ReadMP4File() error = %v", err)
+	}
+
+	mdhdLimit := uint64(0xFFFFFFFF)
+	for _, trak := range muxed.Init.Moov.Traks {
+		mdhd := trak.Mdia.Mdhd
+		if mdhd.Duration > mdhdLimit && mdhd.Version == 0 {
+			t.Fatalf("track %d mdhd has version 0 with duration %d (overflows uint32)", trak.Tkhd.TrackID, mdhd.Duration)
+		}
+		if trak.Tkhd.Duration > mdhdLimit && trak.Tkhd.Version == 0 {
+			t.Fatalf("track %d tkhd has version 0 with duration %d (overflows uint32)", trak.Tkhd.TrackID, trak.Tkhd.Duration)
+		}
+	}
+	mvhd := muxed.Init.Moov.Mvhd
+	if mvhd.Duration > mdhdLimit && mvhd.Version == 0 {
+		t.Fatalf("mvhd has version 0 with duration %d (overflows uint32)", mvhd.Duration)
+	}
+	// And the durations must reflect the input length, not a wrapped value.
+	expectedSeconds := 5.0
+	gotSeconds := float64(mvhd.Duration) / float64(mvhd.Timescale)
+	if gotSeconds < expectedSeconds-0.5 || gotSeconds > expectedSeconds+0.5 {
+		t.Fatalf("mvhd reports %.2fs, want ~%vs", gotSeconds, expectedSeconds)
 	}
 }
 

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -407,6 +407,17 @@ esac
 	}
 	t.Setenv("PATH", dir)
 
+	oldDetectedEncoder := detectedEncoder
+	oldDetectedEncoderOnce := detectedEncoderOnce
+	oldFpsPassthroughFlag := append([]string(nil), fpsPassthroughFlag...)
+	oldFpsPassthroughOnce := fpsPassthroughOnce
+	t.Cleanup(func() {
+		detectedEncoder = oldDetectedEncoder
+		detectedEncoderOnce = oldDetectedEncoderOnce
+		fpsPassthroughFlag = oldFpsPassthroughFlag
+		fpsPassthroughOnce = oldFpsPassthroughOnce
+	})
+
 	detectedEncoder = ""
 	detectedEncoderOnce = sync.Once{}
 	fpsPassthroughFlag = nil


### PR DESCRIPTION
## Summary

Addresses both symptoms reported in #24:

- **Audio sync lost during compression.** `CompressFile` re-encoded video without
  preserving the recorded timeline, so ffmpeg normalized frame cadence and the
  audio drifted away from the picture in the final `.mkv`. Pass
  `-copyts -start_at_zero` on the input and `-fps_mode passthrough`
  + `-avoid_negative_ts make_zero` on the output so the relative timing of
  every sample is carried through the re-encode unchanged.

- **8h recording shown as 1h / 20m with full file size.** The native fMP4 mux
  fallback (`writeCombinedFragmentedMP4`) reused the source video's `moov`
  verbatim, leaving `mvhd.Duration`, `tkhd.Duration` and `mdhd.Duration` at 0.
  Players that read those fields as a hint instead of scanning every fragment
  reported the recording as far shorter than it actually was, while the file on
  disk still contained the full bytes. Sum the trun durations from the
  recorded fragments and write the real duration into mvhd/tkhd/mdhd before
  encoding the output.

The ffmpeg mux path (`MuxAV`) already keeps `-copyts -shortest -avoid_negative_ts make_zero`
from #22; only the re-encode and the no-ffmpeg native fallback needed fixing.

## Test plan

- [x] `go test ./...` passes (new `TestCompressFilePreservesInputTiming`
      pins the compression flags; new `TestNativeMuxWritesNonZeroDuration`
      pins mvhd/tkhd/mdhd durations from real fragment timing)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] Manual: record an LL-HLS stream with `-compress` on, confirm output
      `.mkv` plays in sync end-to-end
- [ ] Manual: record without ffmpeg installed (native fallback), confirm
      reported duration in player matches recorded length

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better A/V alignment during re-encode; improved handling of stream start-time mismatches and consistent encoder/audio flags.
  * MP4 muxer now writes correct track and movie durations across fragments, including promotion for very long durations.

* **Tests**
  * Expanded coverage for compression timing, stream-offset detection, argument ordering, and fragmented MP4 duration/mux correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gogoqaz/chaturbate-dvr/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->