### PR TITLE
[codex] fix max duration init-only split recordings

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -38,6 +38,8 @@ type Channel struct {
 	AudioInitSegment []byte // fMP4 audio init segment for LL-HLS streams
 	HasSeparateAudio bool
 	switchRequested  bool // set by HandleSegment, consumed by OnPollComplete
+	videoMediaBytes  int
+	audioMediaBytes  int
 }
 
 // New creates a new channel instance with the given manager and configuration.

--- a/channel/channel_file.go
+++ b/channel/channel_file.go
@@ -57,6 +57,8 @@ func (ch *Channel) Cleanup() error {
 		ch.CurrentFilename = ""
 		ch.Filesize = 0
 		ch.Duration = 0
+		ch.videoMediaBytes = 0
+		ch.audioMediaBytes = 0
 	}()
 
 	videoFilename, videoInfo, err := closeTrackedFile(ch.File)
@@ -69,10 +71,25 @@ func (ch *Channel) Cleanup() error {
 	}
 
 	if ch.HasSeparateAudio {
+		videoHasMedia := ch.videoMediaBytes > 0
+		audioHasMedia := ch.audioMediaBytes > 0
+		if !videoHasMedia && videoInfo != nil {
+			if err := os.Remove(videoFilename); err != nil {
+				return fmt.Errorf("remove init-only video file: %w", err)
+			}
+			videoInfo = nil
+		}
+		if !audioHasMedia && audioInfo != nil {
+			if err := os.Remove(audioFilename); err != nil {
+				return fmt.Errorf("remove init-only audio file: %w", err)
+			}
+			audioInfo = nil
+		}
+
 		switch {
-		case videoInfo == nil && audioInfo == nil:
+		case !videoHasMedia && !audioHasMedia:
 			return nil
-		case videoInfo == nil:
+		case !videoHasMedia || videoInfo == nil:
 			ch.Info("mux: video track missing; preserving audio-only file %s", filepath.Base(audioFilename))
 			if ch.Config.Compress {
 				ch.CompressFile(audioFilename)
@@ -80,7 +97,7 @@ func (ch *Channel) Cleanup() error {
 				ch.MoveToOutputDir(audioFilename)
 			}
 			return nil
-		case audioInfo == nil:
+		case !audioHasMedia || audioInfo == nil:
 			ch.Info("mux: audio track missing; preserving video-only file %s", filepath.Base(videoFilename))
 			if ch.Config.Compress {
 				ch.CompressFile(videoFilename)
@@ -264,6 +281,9 @@ func (ch *Channel) CreateNewFile(filename string) error {
 	if err := os.MkdirAll(filepath.Dir(filename), 0777); err != nil {
 		return fmt.Errorf("mkdir all: %w", err)
 	}
+
+	ch.videoMediaBytes = 0
+	ch.audioMediaBytes = 0
 
 	videoPath := ch.videoPath(filename)
 	file, err := os.OpenFile(videoPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0777)

--- a/channel/channel_file.go
+++ b/channel/channel_file.go
@@ -71,8 +71,8 @@ func (ch *Channel) Cleanup() error {
 	}
 
 	if ch.HasSeparateAudio {
-		videoHasMedia := ch.videoMediaBytes > 0
-		audioHasMedia := ch.audioMediaBytes > 0
+		videoHasMedia := hasTrackMedia(videoInfo, ch.videoMediaBytes, len(ch.InitSegment))
+		audioHasMedia := hasTrackMedia(audioInfo, ch.audioMediaBytes, len(ch.AudioInitSegment))
 		if !videoHasMedia && videoInfo != nil {
 			if err := os.Remove(videoFilename); err != nil {
 				return fmt.Errorf("remove init-only video file: %w", err)
@@ -144,6 +144,16 @@ func (ch *Channel) Cleanup() error {
 	}
 
 	return nil
+}
+
+func hasTrackMedia(fileInfo os.FileInfo, trackedMediaBytes, initBytes int) bool {
+	if trackedMediaBytes > 0 {
+		return true
+	}
+	if fileInfo == nil {
+		return false
+	}
+	return fileInfo.Size() > int64(initBytes)
 }
 
 // muxOutputLooksValid returns true if the muxed MP4 appears to contain most

--- a/channel/channel_record.go
+++ b/channel/channel_record.go
@@ -225,12 +225,12 @@ func (ch *Channel) HandleSegment(b []byte, duration float64) error {
 	}
 
 	n, err := ch.File.Write(b)
+	ch.videoMediaBytes += n
 	if err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 
 	ch.Filesize += n
-	ch.videoMediaBytes += n
 	ch.Duration += duration
 	ch.Info("duration: %s, filesize: %s", internal.FormatDuration(ch.Duration), internal.FormatFilesize(ch.Filesize))
 
@@ -283,9 +283,9 @@ func (ch *Channel) HandleAudioSegment(b []byte, _ float64) error {
 	}
 
 	n, err := ch.AudioFile.Write(b)
+	ch.audioMediaBytes += n
 	if err != nil {
 		return fmt.Errorf("write audio file: %w", err)
 	}
-	ch.audioMediaBytes += n
 	return nil
 }

--- a/channel/channel_record.go
+++ b/channel/channel_record.go
@@ -230,6 +230,7 @@ func (ch *Channel) HandleSegment(b []byte, duration float64) error {
 	}
 
 	ch.Filesize += n
+	ch.videoMediaBytes += n
 	ch.Duration += duration
 	ch.Info("duration: %s, filesize: %s", internal.FormatDuration(ch.Duration), internal.FormatFilesize(ch.Filesize))
 
@@ -281,8 +282,10 @@ func (ch *Channel) HandleAudioSegment(b []byte, _ float64) error {
 		return retry.Unrecoverable(internal.ErrPaused)
 	}
 
-	if _, err := ch.AudioFile.Write(b); err != nil {
+	n, err := ch.AudioFile.Write(b)
+	if err != nil {
 		return fmt.Errorf("write audio file: %w", err)
 	}
+	ch.audioMediaBytes += n
 	return nil
 }

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -223,6 +223,38 @@ func TestCleanupDropsInitOnlySeparateTrackFiles(t *testing.T) {
 	}
 }
 
+func TestCleanupPreservesUncountedPartialMediaBytes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	base := filepath.Join(dir, "recording")
+	audioPath := base + ".audio.mp4"
+	audioInit := []byte("audio-init")
+	audioFile, err := os.OpenFile(audioPath, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("open audio file: %v", err)
+	}
+	if _, err := audioFile.Write(append([]byte{}, audioInit...)); err != nil {
+		t.Fatalf("write audio init: %v", err)
+	}
+	if _, err := audioFile.Write([]byte("partial-media")); err != nil {
+		t.Fatalf("write audio media: %v", err)
+	}
+
+	ch := New(&entity.ChannelConfig{Username: "alice", Pattern: base})
+	ch.HasSeparateAudio = true
+	ch.CurrentFilename = base
+	ch.AudioInitSegment = audioInit
+	ch.AudioFile = audioFile
+
+	if err := ch.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if _, err := os.Stat(audioPath); err != nil {
+		t.Fatalf("audio file with uncounted media bytes should be preserved, stat err = %v", err)
+	}
+}
+
 func TestCreateNewFileKeepsLegacyHLSAsTS(t *testing.T) {
 	t.Parallel()
 

--- a/channel/channel_record_test.go
+++ b/channel/channel_record_test.go
@@ -134,6 +134,11 @@ func buildFragmentedMP4WithSamples(t *testing.T, mediaType string, timescale uin
 	return buf.Bytes()
 }
 
+func markSeparateTrackMediaWritten(ch *Channel, videoData, audioData []byte) {
+	ch.videoMediaBytes = len(videoData)
+	ch.audioMediaBytes = len(audioData)
+}
+
 func TestCleanupNativeMuxesSeparateTracksWhenFFmpegUnavailable(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("PATH", dir)
@@ -154,6 +159,7 @@ func TestCleanupNativeMuxesSeparateTracksWhenFFmpegUnavailable(t *testing.T) {
 	if err := ch.CreateNewFile(base); err != nil {
 		t.Fatalf("CreateNewFile() error = %v", err)
 	}
+	markSeparateTrackMediaWritten(ch, videoMP4, audioMP4)
 
 	if err := ch.Cleanup(); err != nil {
 		t.Fatalf("Cleanup() error = %v", err)
@@ -181,6 +187,39 @@ func TestCleanupNativeMuxesSeparateTracksWhenFFmpegUnavailable(t *testing.T) {
 	}
 	if len(muxed.Init.Moov.Traks) != 2 {
 		t.Fatalf("expected 2 tracks in muxed output, got %d", len(muxed.Init.Moov.Traks))
+	}
+}
+
+func TestCleanupDropsInitOnlySeparateTrackFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	base := filepath.Join(dir, "recording")
+	ch := New(&entity.ChannelConfig{
+		Username: "alice",
+		Pattern:  base,
+	})
+	ch.HasSeparateAudio = true
+	ch.CurrentFilename = base
+	ch.InitSegment = []byte("video-init-only")
+	ch.AudioInitSegment = []byte("audio-init-only")
+
+	if err := ch.CreateNewFile(base); err != nil {
+		t.Fatalf("CreateNewFile() error = %v", err)
+	}
+
+	if err := ch.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	if _, err := os.Stat(base + ".mp4"); !os.IsNotExist(err) {
+		t.Fatalf("expected no muxed output for init-only files, stat err = %v", err)
+	}
+	if _, err := os.Stat(base + ".video.mp4"); !os.IsNotExist(err) {
+		t.Fatalf("expected init-only video sidecar removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(base + ".audio.mp4"); !os.IsNotExist(err) {
+		t.Fatalf("expected init-only audio sidecar removed, stat err = %v", err)
 	}
 }
 
@@ -312,6 +351,7 @@ func TestCleanupPreservesAudioOnlyWhenVideoMissing(t *testing.T) {
 	ch.HasSeparateAudio = true
 	ch.CurrentFilename = base
 	ch.AudioFile = audioFile
+	ch.audioMediaBytes = len("audio-payload")
 
 	if err := ch.Cleanup(); err != nil {
 		t.Fatalf("Cleanup() error = %v", err)
@@ -337,6 +377,7 @@ func TestCleanupPreservesVideoOnlyWhenAudioMissing(t *testing.T) {
 	ch.HasSeparateAudio = true
 	ch.CurrentFilename = base
 	ch.File = videoFile
+	ch.videoMediaBytes = len("video-payload")
 
 	if err := ch.Cleanup(); err != nil {
 		t.Fatalf("Cleanup() error = %v", err)
@@ -575,6 +616,7 @@ func TestNativeMuxPromotesVersionForLongDurations(t *testing.T) {
 	if err := ch.CreateNewFile(base); err != nil {
 		t.Fatalf("CreateNewFile() error = %v", err)
 	}
+	markSeparateTrackMediaWritten(ch, videoMP4, audioMP4)
 	if err := ch.Cleanup(); err != nil {
 		t.Fatalf("Cleanup() error = %v", err)
 	}
@@ -640,6 +682,7 @@ func TestNativeMuxWritesNonZeroDuration(t *testing.T) {
 	if err := ch.CreateNewFile(base); err != nil {
 		t.Fatalf("CreateNewFile() error = %v", err)
 	}
+	markSeparateTrackMediaWritten(ch, videoMP4, audioMP4)
 	if err := ch.Cleanup(); err != nil {
 		t.Fatalf("Cleanup() error = %v", err)
 	}


### PR DESCRIPTION
## Summary

- Track whether split video/audio files contain real media segments, not just fMP4 init data.
- Drop init-only split sidecars during cleanup instead of attempting to mux or preserve 1 KB placeholder files.
- Add a regression test for the Max Duration rotation case that created init-only `.video.mp4` / `.audio.mp4` files.

## Root Cause

When a separate-audio LL-HLS recording hit Max Duration, rotation created the next split files and immediately wrote the cached init segments. If `RecordStream` exited before any media segments arrived for that new file, deferred cleanup treated those non-empty init-only sidecars as complete inputs and tried to mux them. The mux sanity check then rejected the tiny output and preserved the 1 KB sidecars.

## Verification

- `env GOCACHE=/Users/pxchen/chaturbate-dvr/.gocache go test ./...`
- `env GOCACHE=/Users/pxchen/chaturbate-dvr/.gocache go vet ./...`

Fixes #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliably detects and removes init-only audio/video sidecar files during cleanup, while preserving recordings that contain any actual media bytes (including partial media).

* **Tests**
  * Added tests to verify init-only separate-track removal and preservation behavior for partial or single-track recordings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gogoqaz/chaturbate-dvr/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->