### PR TITLE
fix: normalize channel usernames

### DIFF
--- a/entity/entity.go
+++ b/entity/entity.go
@@ -29,6 +29,7 @@ type ChannelConfig struct {
 func (c *ChannelConfig) Sanitize() {
 	c.Username = regexp.MustCompile(`[^a-zA-Z0-9_-]`).ReplaceAllString(c.Username, "")
 	c.Username = strings.TrimSpace(c.Username)
+	c.Username = strings.ToLower(c.Username)
 }
 
 // ChannelInfo represents the information about a channel,

--- a/entity/entity_test.go
+++ b/entity/entity_test.go
@@ -1,0 +1,13 @@
+package entity
+
+import "testing"
+
+func TestChannelConfigSanitizeLowercasesUsername(t *testing.T) {
+	conf := &ChannelConfig{Username: "Alice-01!"}
+
+	conf.Sanitize()
+
+	if conf.Username != "alice-01" {
+		t.Fatalf("username = %q, want %q", conf.Username, "alice-01")
+	}
+}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -73,11 +73,19 @@ func (m *Manager) LoadConfig() error {
 	if err := json.Unmarshal(b, &config); err != nil {
 		return fmt.Errorf("unmarshal: %w", err)
 	}
+	config, err = prepareLoadedConfigs(config)
+	if err != nil {
+		return err
+	}
+	for _, conf := range config {
+		if _, exists := m.Channels.Load(conf.Username); exists {
+			return fmt.Errorf("duplicate username after sanitize: %q", conf.Username)
+		}
+	}
 
 	pausedSeq := 0
 	seq := 0
 	for _, conf := range config {
-		conf.Sanitize()
 		ch := channel.New(conf)
 		m.Channels.Store(conf.Username, ch)
 
@@ -93,6 +101,24 @@ func (m *Manager) LoadConfig() error {
 		seq++
 	}
 	return nil
+}
+
+func prepareLoadedConfigs(configs []*entity.ChannelConfig) ([]*entity.ChannelConfig, error) {
+	seen := make(map[string]struct{}, len(configs))
+	for _, conf := range configs {
+		if conf == nil {
+			return nil, fmt.Errorf("empty channel config")
+		}
+		conf.Sanitize()
+		if conf.Username == "" {
+			return nil, fmt.Errorf("empty username after sanitize")
+		}
+		if _, ok := seen[conf.Username]; ok {
+			return nil, fmt.Errorf("duplicate username after sanitize: %q", conf.Username)
+		}
+		seen[conf.Username] = struct{}{}
+	}
+	return configs, nil
 }
 
 // CreateChannel starts monitoring an M3U8 stream

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -77,6 +77,7 @@ func (m *Manager) LoadConfig() error {
 	pausedSeq := 0
 	seq := 0
 	for _, conf := range config {
+		conf.Sanitize()
 		ch := channel.New(conf)
 		m.Channels.Store(conf.Username, ch)
 

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -1,0 +1,69 @@
+package manager
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/teacat/chaturbate-dvr/entity"
+)
+
+func TestPrepareLoadedConfigsRejectsDuplicateSanitizedUsernames(t *testing.T) {
+	configs := []*entity.ChannelConfig{
+		{Username: "Alice"},
+		{Username: "alice"},
+	}
+
+	_, err := prepareLoadedConfigs(configs)
+
+	if err == nil {
+		t.Fatal("expected duplicate sanitized username error")
+	}
+	if !strings.Contains(err.Error(), `duplicate username after sanitize: "alice"`) {
+		t.Fatalf("error = %q, want duplicate alice error", err.Error())
+	}
+}
+
+func TestPrepareLoadedConfigsRejectsEmptySanitizedUsernames(t *testing.T) {
+	configs := []*entity.ChannelConfig{
+		{Username: "!!!"},
+	}
+
+	_, err := prepareLoadedConfigs(configs)
+
+	if err == nil {
+		t.Fatal("expected empty sanitized username error")
+	}
+	if !strings.Contains(err.Error(), "empty username after sanitize") {
+		t.Fatalf("error = %q, want empty username error", err.Error())
+	}
+}
+
+func TestLoadConfigRejectsDuplicateSanitizedUsernames(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll("./conf", 0777); err != nil {
+		t.Fatalf("mkdir conf: %v", err)
+	}
+	if err := os.WriteFile("./conf/channels.json", []byte(`[
+  {"username":"Alice"},
+  {"username":"alice"}
+]`), 0666); err != nil {
+		t.Fatalf("write channels config: %v", err)
+	}
+	m, err := New()
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	err = m.LoadConfig()
+
+	if err == nil {
+		t.Fatal("expected duplicate sanitized username error")
+	}
+	if !strings.Contains(err.Error(), `duplicate username after sanitize: "alice"`) {
+		t.Fatalf("error = %q, want duplicate alice error", err.Error())
+	}
+	if _, ok := m.Channels.Load("alice"); ok {
+		t.Fatal("duplicate config should fail before storing channels")
+	}
+}


### PR DESCRIPTION
## Summary

- Normalize channel usernames to lowercase during sanitization.
- Sanitize usernames loaded from persisted `conf/channels.json`.
- Add a regression test for uppercase channel usernames.

## Root cause

When an offline model was added with an uppercase first letter, the username could be persisted and later used directly in the Chaturbate API URL. That could return HTML instead of JSON, producing `invalid character '<' looking for beginning of value`.

## Validation

- `go test ./...`

Fixes #11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Channel configuration usernames are now automatically normalized to lowercase during sanitization, ensuring consistent handling and eliminating case-related inconsistencies.
  * Configuration loading now systematically applies sanitization to all channel configurations for improved data consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->