### PR TITLE
fix: require explicit compression opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Available options:
 --cookies value             Cookies to use in the request (format: key=value; key2=value2)
 --user-agent value          Custom User-Agent for the request
 --domain value              Chaturbate domain to use (default: "https://chaturbate.global/")
---compress                  Compress recorded .ts or .mp4 files to .mkv after recording (auto-enabled if ffmpeg installed)
+--compress                  Compress recorded .ts or .mp4 files to .mkv after recording
 --help, -h                  show help
 --version, -v               print the version
 ```
@@ -120,8 +120,8 @@ $ ./chaturbate-dvr -u yamiodymel -max-filesize 1024
 $ ./chaturbate-dvr -u yamiodymel \
     -pattern "video/{{.Username}}/{{.Year}}-{{.Month}}-{{.Day}}_{{.Hour}}-{{.Minute}}-{{.Second}}_{{.Sequence}}"
 
-# Disable auto-compression
-$ ./chaturbate-dvr -u yamiodymel --compress=false
+# Enable compression to MKV after recording
+$ ./chaturbate-dvr -u yamiodymel --compress
 ```
 
 _Note: In Web UI mode, these flags serve as default values for new channels._

--- a/config/config.go
+++ b/config/config.go
@@ -1,26 +1,12 @@
 package config
 
 import (
-	"os/exec"
-
 	"github.com/teacat/chaturbate-dvr/entity"
 	"github.com/urfave/cli/v2"
 )
 
-// HasFFmpeg checks if ffmpeg is installed and available in PATH.
-func HasFFmpeg() bool {
-	_, err := exec.LookPath("ffmpeg")
-	return err == nil
-}
-
 // New initializes a new Config struct with values from the CLI context.
 func New(c *cli.Context) (*entity.Config, error) {
-	// Auto-enable compress if ffmpeg is available and user didn't explicitly set --compress=false
-	compress := c.Bool("compress")
-	if !c.IsSet("compress") && HasFFmpeg() {
-		compress = true
-	}
-
 	return &entity.Config{
 		Version:        c.App.Version,
 		Username:       c.String("username"),
@@ -31,7 +17,7 @@ func New(c *cli.Context) (*entity.Config, error) {
 		Pattern:        c.String("pattern"),
 		MaxDuration:    c.Int("max-duration"),
 		MaxFilesize:    c.Int("max-filesize"),
-		Compress:       compress,
+		Compress:       c.Bool("compress"),
 		Port:           c.String("port"),
 		Interval:       c.Int("interval"),
 		Cookies:        c.String("cookies"),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestNewDoesNotAutoEnableCompressWhenFFmpegExists(t *testing.T) {
+	set := newConfigFlagSet(t)
+	t.Setenv("PATH", fakeFFmpegDir(t))
+
+	conf, err := New(newConfigContext(set))
+	if err != nil {
+		t.Fatalf("new config: %v", err)
+	}
+
+	if conf.Compress {
+		t.Fatal("compress = true, want false unless --compress is explicitly set")
+	}
+}
+
+func TestNewEnablesCompressWhenFlagIsExplicit(t *testing.T) {
+	set := newConfigFlagSet(t, "--compress")
+	t.Setenv("PATH", fakeFFmpegDir(t))
+
+	conf, err := New(newConfigContext(set))
+	if err != nil {
+		t.Fatalf("new config: %v", err)
+	}
+
+	if !conf.Compress {
+		t.Fatal("compress = false, want true when --compress is explicitly set")
+	}
+}
+
+func newConfigFlagSet(t *testing.T, args ...string) *flag.FlagSet {
+	t.Helper()
+
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	compressFlag := &cli.BoolFlag{Name: "compress"}
+	if err := compressFlag.Apply(set); err != nil {
+		t.Fatalf("apply compress flag: %v", err)
+	}
+	if err := set.Parse(args); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	return set
+}
+
+func newConfigContext(set *flag.FlagSet) *cli.Context {
+	return cli.NewContext(&cli.App{Version: "test"}, set, nil)
+}
+
+func fakeFFmpegDir(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ffmpeg")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	return dir
+}

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main() {
 			},
 			&cli.BoolFlag{
 				Name:  "compress",
-				Usage: "Compress recorded files (.ts or .mp4) to .mkv using ffmpeg after recording (auto-enabled if ffmpeg is installed)",
+				Usage: "Compress recorded files (.ts or .mp4) to .mkv using ffmpeg after recording",
 				Value: false,
 			},
 			&cli.StringFlag{


### PR DESCRIPTION
## Summary

- remove the ffmpeg-installed auto-enable path for compression defaults
- keep compression as an explicit opt-in via `--compress`
- update CLI/README copy so the documented behavior matches the default
- add config regression coverage for ffmpeg-present and explicit flag cases

## Root cause

`config.New()` treated ffmpeg availability as consent to enable compression when `--compress` was not explicitly set. In Web UI mode, that process-level config is used as the default for new channel forms, so new records were checked for compression automatically whenever ffmpeg was installed.

## Validation

- `go test ./...`
- `git diff --check`

Closes #29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI documentation for the `--compress` flag and usage examples

* **Bug Fixes**
  * Modified `--compress` flag behavior to no longer auto-enable based on ffmpeg availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->