### PR TITLE
fix: prevent stalled SSE client from stalling recording (#34)

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -222,7 +222,17 @@ func (m *Manager) ChannelInfo() []*entity.ChannelInfo {
 	return channels
 }
 
-// Publish sends an SSE event to the specified channel.
+// Publish sends an SSE event to subscribers of the "updates" stream.
+//
+// It uses TryPublish (non-blocking) rather than Publish: SSE carries only
+// ephemeral UI updates, so when the stream buffer is full the event is dropped
+// and the next successful publish re-syncs the client. This decoupling is
+// critical because Publish runs on the recording hot path
+// (Channel.Publisher -> Info/Update -> HandleSegment). A blocking publish there
+// lets a single slow or stalled SSE client (e.g. a browser tab suspended when a
+// laptop lid closes while the TCP connection stays half-open) apply backpressure
+// all the way back into the recording loop, stalling every channel until the
+// client disconnects. See issue #34.
 func (m *Manager) Publish(evt entity.Event, info *entity.ChannelInfo) {
 	switch evt {
 	case entity.EventUpdate:
@@ -231,12 +241,12 @@ func (m *Manager) Publish(evt entity.Event, info *entity.ChannelInfo) {
 			fmt.Println("Error executing template:", err)
 			return
 		}
-		m.SSE.Publish("updates", &sse.Event{
+		m.SSE.TryPublish("updates", &sse.Event{
 			Event: []byte(info.Username + "-info"),
 			Data:  b.Bytes(),
 		})
 	case entity.EventLog:
-		m.SSE.Publish("updates", &sse.Event{
+		m.SSE.TryPublish("updates", &sse.Event{
 			Event: []byte(info.Username + "-log"),
 			Data:  []byte(strings.Join(info.Logs, "\n")),
 		})

--- a/manager/manager_publish_test.go
+++ b/manager/manager_publish_test.go
@@ -1,0 +1,109 @@
+package manager
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/r3labs/sse/v2"
+	"github.com/teacat/chaturbate-dvr/entity"
+)
+
+// stalledResponseWriter is an http.ResponseWriter + http.Flusher whose Write
+// blocks until release is closed. It simulates an SSE client that has stopped
+// reading its response body (e.g. a browser tab suspended when a laptop lid
+// closes while the TCP connection stays half-open), which is what stalls the
+// SSE delivery goroutine in the real failure (issue #34).
+type stalledResponseWriter struct {
+	header     http.Header
+	release    chan struct{}
+	firstWrite chan struct{}
+	once       sync.Once
+}
+
+func newStalledResponseWriter() *stalledResponseWriter {
+	return &stalledResponseWriter{
+		header:     make(http.Header),
+		release:    make(chan struct{}),
+		firstWrite: make(chan struct{}),
+	}
+}
+
+func (w *stalledResponseWriter) Header() http.Header { return w.header }
+func (w *stalledResponseWriter) WriteHeader(int)     {}
+func (w *stalledResponseWriter) Flush()              {}
+
+func (w *stalledResponseWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.firstWrite) })
+	<-w.release
+	return len(p), nil
+}
+
+// TestPublishDoesNotBlockOnStalledSubscriber guards against issue #34: a slow or
+// stalled SSE client must never apply backpressure to Manager.Publish. Publish
+// runs on the recording hot path, so a blocking publish stalls recording for
+// every channel until the client disconnects. With the blocking sse.Publish this
+// test deadlocks; with the non-blocking sse.TryPublish it passes.
+func TestPublishDoesNotBlockOnStalledSubscriber(t *testing.T) {
+	m, err := New()
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	// A cancelable context lets us deregister the subscriber on cleanup so the
+	// SSE handler goroutine can exit instead of leaking.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := newStalledResponseWriter()
+	req := httptest.NewRequest(http.MethodGet, "/updates?stream=updates", nil).WithContext(ctx)
+	go m.Subscriber(w, req)
+
+	info := &entity.ChannelInfo{Username: "tester", Logs: []string{"hello"}}
+
+	// The SSE handler registers its subscriber asynchronously, so an event
+	// published before registration is dropped. Keep publishing until the
+	// handler pulls one from the subscriber's connection channel and blocks
+	// inside Write: once firstWrite fires the subscriber is registered and its
+	// delivery path is stalled.
+	stalled := false
+	deadline := time.Now().Add(3 * time.Second)
+	for !stalled && time.Now().Before(deadline) {
+		m.Publish(entity.EventLog, info)
+		select {
+		case <-w.firstWrite:
+			stalled = true
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	if !stalled {
+		t.Fatal("SSE handler never wrote; subscriber did not register/stall as expected")
+	}
+
+	// Flood past the SSE stream buffer plus the per-subscriber connection buffer
+	// (hardcoded to 64 in r3labs/sse). Beyond that a blocking publish deadlocks;
+	// TryPublish drops events and every call returns immediately.
+	const perSubscriberBuffer = 64
+	floodCount := sse.DefaultBufferSize + perSubscriberBuffer + 256
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < floodCount; i++ {
+			m.Publish(entity.EventLog, info)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Every Publish returned even though the subscriber is stalled.
+	case <-time.After(5 * time.Second):
+		close(w.release) // unblock the handler so the flood goroutine can finish
+		t.Fatal("Manager.Publish blocked on a stalled SSE subscriber; recording would stall (issue #34)")
+	}
+
+	close(w.release)
+}


### PR DESCRIPTION
## Problem

Fixes #34. Occasionally **all** recording streams stop at once, get muxed, and immediately restart. It correlates exactly with an SSE `/updates` connection closing, and is reproducible when a Mac keeps the page open with the lid closed.

## Root cause

Recording is coupled to SSE delivery through blocking Go channels. A slow or stalled SSE client (a browser tab suspended when the laptop lid closes, with the TCP connection left half-open) applies backpressure that propagates all the way back into the recording hot loop:

```
stalled client stops reading the response body
  -> per-subscriber connection buffer (64) fills
  -> stream run() goroutine blocks on `connection <- event`
  -> stream event buffer (1024) fills
  -> SSE.Publish() blocks
  -> Channel.Publisher() blocks
  -> the unbuffered LogCh / UpdateCh block
  -> HandleSegment() blocks
  -> recording stalls for ALL channels (they share one SSE server/stream)
```

When the connection finally drops, everything unblocks, but by then the HLS playlist/token has expired; the next segment fetch fails, `RecordStream` returns an error, the deferred `Cleanup` muxes the file, and the retry loop restarts recording ~1 min later.

This matches the logs in the issue precisely: every `[GIN] ... GET "/updates?stream=updates"` close (8m21s, 16m12s, ...) is immediately followed by all channels muxing and restarting. It also explains why the failure hits every channel simultaneously, is tied to the page being open with the lid closed, and is not a Chaturbate/network problem (a fork without this SSE coupling keeps recording).

## Fix

Switch `Manager.Publish` from the blocking `SSE.Publish` to the non-blocking `SSE.TryPublish`. SSE carries only ephemeral UI updates, so dropping an event when the stream buffer is full is acceptable -- the next successful publish re-syncs the client. Recording is now fully decoupled from SSE delivery, and a slow/stalled client can no longer apply backpressure to the recording loop.

## Test

Adds `TestPublishDoesNotBlockOnStalledSubscriber`: it stalls an SSE subscriber with a `Write`-blocking `ResponseWriter`, floods past the stream buffer (1024) and per-subscriber connection buffer (64), and asserts that `Publish` never blocks the caller.

- Fails (deadlocks -> timeout) against the old blocking `Publish`; passes with `TryPublish`.
- Stable across 20 runs with `-race`.
- Full `go test ./...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented event publishing from blocking when an SSE client becomes stalled.
  * Ensured the application remains responsive under slow or disconnected event-stream clients.
  * Added coverage to verify publishing completes promptly during high-volume updates.

* **Documentation**
  * Clarified SSE delivery behavior, including possible event drops and client resynchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->