### PR TITLE
fix: focus channel after add and resume existing channel on re-add

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/teacat/chaturbate-dvr/chaturbate"
@@ -20,6 +21,10 @@ type Channel struct {
 	PauseCancelFunc context.CancelFunc
 	LogCh           chan string
 	UpdateCh        chan bool
+
+	// pauseMu guards the IsPaused state transition so concurrent resumes can't
+	// both start a Monitor goroutine. See ResumeIfPaused.
+	pauseMu sync.Mutex
 
 	IsOnline   bool
 	RoomStatus string // public, private, group, away, offline
@@ -131,7 +136,10 @@ func (ch *Channel) Pause() {
 	// `context.Canceled` → `ch.Monitor()` → `onRetry` → `ch.UpdateOnlineStatus(false)`.
 	ch.CancelFunc()
 
+	ch.pauseMu.Lock()
 	ch.Config.IsPaused = true
+	ch.pauseMu.Unlock()
+
 	ch.Update()
 	ch.Info("channel paused")
 
@@ -152,9 +160,32 @@ func (ch *Channel) Stop() {
 // `startSeq` is used to prevent all channels from starting at the same time, preventing TooManyRequests errors.
 // It's only be used when program starting and trying to resume all channels at once.
 func (ch *Channel) Resume(startSeq int) {
-	ch.PauseCancelFunc()
+	ch.pauseMu.Lock()
 	ch.Config.IsPaused = false
+	ch.pauseMu.Unlock()
 
+	ch.resume(startSeq)
+}
+
+// ResumeIfPaused resumes the channel only when it is currently paused, flipping
+// the paused state atomically so that concurrent callers cannot both start a
+// Monitor goroutine. It reports whether this call performed the resume.
+func (ch *Channel) ResumeIfPaused(startSeq int) bool {
+	ch.pauseMu.Lock()
+	if !ch.Config.IsPaused {
+		ch.pauseMu.Unlock()
+		return false
+	}
+	ch.Config.IsPaused = false
+	ch.pauseMu.Unlock()
+
+	ch.resume(startSeq)
+	return true
+}
+
+// resume performs the actual resume work once the paused state has been cleared.
+func (ch *Channel) resume(startSeq int) {
+	ch.PauseCancelFunc()
 	ch.Update()
 	ch.Info("channel resumed")
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -124,13 +124,13 @@ func prepareLoadedConfigs(configs []*entity.ChannelConfig) ([]*entity.ChannelCon
 // CreateChannel starts monitoring an M3U8 stream
 func (m *Manager) CreateChannel(conf *entity.ChannelConfig, shouldSave bool) error {
 	conf.Sanitize()
-	ch := channel.New(conf)
 
-	// prevent duplicate channels
-	_, ok := m.Channels.Load(conf.Username)
-	if ok {
+	// Prevent duplicate channels. Check before channel.New so a duplicate does
+	// not leak the Publisher goroutine that New starts.
+	if _, ok := m.Channels.Load(conf.Username); ok {
 		return fmt.Errorf("channel %s already exists", conf.Username)
 	}
+	ch := channel.New(conf)
 	m.Channels.Store(conf.Username, ch)
 
 	go ch.Resume(0)
@@ -172,13 +172,21 @@ func (m *Manager) PauseChannel(username string) error {
 	return nil
 }
 
-// ResumeChannel resumes the channel.
+// ResumeChannel resumes the channel if it is paused.
+//
+// Resuming an already-active channel is a no-op: calling Resume on a running
+// channel would spawn a second Monitor goroutine. This guard makes ResumeChannel
+// safe to call when re-adding a channel that already exists.
 func (m *Manager) ResumeChannel(username string) error {
 	thing, ok := m.Channels.Load(username)
 	if !ok {
 		return nil
 	}
-	thing.(*channel.Channel).Resume(0)
+	ch := thing.(*channel.Channel)
+	if !ch.Config.IsPaused {
+		return nil
+	}
+	ch.Resume(0)
 
 	if err := m.SaveConfig(); err != nil {
 		return fmt.Errorf("save config: %w", err)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -125,13 +125,18 @@ func prepareLoadedConfigs(configs []*entity.ChannelConfig) ([]*entity.ChannelCon
 func (m *Manager) CreateChannel(conf *entity.ChannelConfig, shouldSave bool) error {
 	conf.Sanitize()
 
-	// Prevent duplicate channels. Check before channel.New so a duplicate does
-	// not leak the Publisher goroutine that New starts.
+	// Fast path: reject an already-known duplicate before channel.New, so the
+	// common re-add case never spawns the Publisher goroutine that New starts.
 	if _, ok := m.Channels.Load(conf.Username); ok {
 		return fmt.Errorf("channel %s already exists", conf.Username)
 	}
 	ch := channel.New(conf)
-	m.Channels.Store(conf.Username, ch)
+	// Store atomically to close the race where two concurrent creates of the
+	// same username both pass the Load above; the loser cleans up its channel.
+	if _, loaded := m.Channels.LoadOrStore(conf.Username, ch); loaded {
+		ch.Stop()
+		return fmt.Errorf("channel %s already exists", conf.Username)
+	}
 
 	go ch.Resume(0)
 
@@ -175,18 +180,17 @@ func (m *Manager) PauseChannel(username string) error {
 // ResumeChannel resumes the channel if it is paused.
 //
 // Resuming an already-active channel is a no-op: calling Resume on a running
-// channel would spawn a second Monitor goroutine. This guard makes ResumeChannel
-// safe to call when re-adding a channel that already exists.
+// channel would spawn a second Monitor goroutine. ResumeIfPaused performs the
+// check-and-resume atomically, so this is safe to call concurrently and when
+// re-adding a channel that already exists.
 func (m *Manager) ResumeChannel(username string) error {
 	thing, ok := m.Channels.Load(username)
 	if !ok {
 		return nil
 	}
-	ch := thing.(*channel.Channel)
-	if !ch.Config.IsPaused {
+	if !thing.(*channel.Channel).ResumeIfPaused(0) {
 		return nil
 	}
-	ch.Resume(0)
 
 	if err := m.SaveConfig(); err != nil {
 		return fmt.Errorf("save config: %w", err)

--- a/router/router_handler.go
+++ b/router/router_handler.go
@@ -3,6 +3,7 @@ package router
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -44,8 +45,9 @@ func CreateChannel(c *gin.Context) {
 		return
 	}
 
+	var focus string
 	for _, username := range strings.Split(req.Username, ",") {
-		server.Manager.CreateChannel(&entity.ChannelConfig{
+		conf := &entity.ChannelConfig{
 			IsPaused:    false,
 			Username:    username,
 			Framerate:   req.Framerate,
@@ -55,7 +57,25 @@ func CreateChannel(c *gin.Context) {
 			MaxFilesize: req.MaxFilesize,
 			Compress:    req.Compress,
 			CreatedAt:   time.Now().Unix(),
-		}, true)
+		}
+		conf.Sanitize()
+		if conf.Username == "" {
+			continue
+		}
+		// Focus the first valid channel from the submitted list once the page reloads.
+		if focus == "" {
+			focus = conf.Username
+		}
+		// If the channel already exists, resume it (when paused) instead of
+		// silently doing nothing, so re-adding a channel visibly starts recording.
+		if err := server.Manager.CreateChannel(conf, true); err != nil {
+			server.Manager.ResumeChannel(conf.Username)
+		}
+	}
+
+	if focus != "" {
+		c.Redirect(http.StatusFound, "/?focus="+url.QueryEscape(focus))
+		return
 	}
 	c.Redirect(http.StatusFound, "/")
 }

--- a/router/view/templates/index.html
+++ b/router/view/templates/index.html
@@ -411,9 +411,16 @@
             document.addEventListener("DOMContentLoaded", function() {
                 updateRecordingCount();
 
-                // First load always lands on the channel list — skip the mobile flip into detail view.
+                // A ?focus=<username> param (set after adding a channel) wins so the
+                // newly added — or re-added existing — channel is shown right away.
+                var focus = new URLSearchParams(window.location.search).get('focus');
                 var saved = sessionStorage.getItem('selectedChannel');
-                if (saved && document.querySelector('[data-channel="' + saved + '"]')) {
+                if (focus && document.querySelector('[data-channel="' + focus + '"]')) {
+                    // Strip ?focus from the URL so a later refresh doesn't re-force it.
+                    history.replaceState(history.state, '', window.location.pathname);
+                    selectChannel(focus);
+                } else if (saved && document.querySelector('[data-channel="' + saved + '"]')) {
+                    // First load always lands on the channel list — skip the mobile flip into detail view.
                     selectChannel(saved, true);
                 } else {
                     sessionStorage.removeItem('selectedChannel');

--- a/router/view/templates/index.html
+++ b/router/view/templates/index.html
@@ -415,11 +415,11 @@
                 // newly added — or re-added existing — channel is shown right away.
                 var focus = new URLSearchParams(window.location.search).get('focus');
                 var saved = sessionStorage.getItem('selectedChannel');
-                if (focus && document.querySelector('[data-channel="' + focus + '"]')) {
+                if (focus && document.querySelector('[data-channel="' + CSS.escape(focus) + '"]')) {
                     // Strip ?focus from the URL so a later refresh doesn't re-force it.
                     history.replaceState(history.state, '', window.location.pathname);
                     selectChannel(focus);
-                } else if (saved && document.querySelector('[data-channel="' + saved + '"]')) {
+                } else if (saved && document.querySelector('[data-channel="' + CSS.escape(saved) + '"]')) {
                     // First load always lands on the channel list — skip the mobile flip into detail view.
                     selectChannel(saved, true);
                 } else {


### PR DESCRIPTION
## Problems

1. After adding a channel, the web UI kept the previously selected channel focused instead of showing the one just added.
2. Re-adding a channel that already exists did nothing visible — the request silently redirected to `/` with no feedback, leaving the user confused.

## Changes

- **Focus after add** — `CreateChannel` now redirects to `/?focus=<username>`. On load, the frontend selects that channel (opening its detail panel, and flipping to the detail view on mobile) and strips the query param so a later refresh doesn't re-force it.
- **Re-add resumes instead of doing nothing** — when the channel already exists, the handler resumes it and focuses it. `ResumeChannel` only resumes when the channel is actually paused, so re-adding a channel that is already recording just focuses it without spawning a second `Monitor` goroutine.
- **Goroutine leak fix** — move the duplicate check before `channel.New` so a rejected duplicate no longer leaks the `Publisher` goroutine that `New` starts (this path is now hit on every re-add).

Usernames are sanitized before building the redirect so the `focus` param matches the rendered `data-channel` value.

## Testing

- `go build ./...` passes; existing `manager` / `router` tests pass.
- Manual (curl): adding a new channel returns `302 → /?focus=testalice`; re-adding the same channel returns the same redirect (no longer silent); pausing then re-adding flips `is_paused` back to `false` with a single channel entry (no duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - After creating channels, the app now automatically opens the first successfully created channel.
  - Channel names are sanitized, and invalid or empty entries are skipped.
  - Direct channel selection via the `focus` URL parameter is now supported.

- **Bug Fixes**
  - Duplicate channels are rejected without triggering unnecessary channel activity.
  - Resuming an already active channel no longer starts duplicate monitoring behavior.
  - Existing channel selection preferences continue to work when no focused channel is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->